### PR TITLE
개별 문서 아이템 컴포넌트 구현 및 클릭 시 라우팅 구현 

### DIFF
--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import trashIcon from '../../assets/trash.svg';
 import bookmarkIcon from '../../assets/bookmark.svg';
+import { FILTER_TO_CAUTION, FILTER_TO_ACTIVE } from '../../constants/styled';
 
 interface docListItemProps {
   id: string,
@@ -13,22 +14,22 @@ interface docListItemProps {
 
 const DocListItem = ({id, title, lastVisited, role}: docListItemProps) => {
   return (
-    <Link to={id}>
-      <DocListItemWrapper>
+    <DocListItemWrapper>
+      <Link to={id}>
         <Title>{title}</Title>
         <LowerLayout>
           <LastVisited>최근 방문일: {lastVisited}</LastVisited>
           <div>
             {role === 'onwer' && <button>
-              <ImgOnBtn src={trashIcon} alt="삭제하기 버튼" />
+              <ImgOnBtn color={FILTER_TO_CAUTION} src={trashIcon} alt="삭제하기 버튼" />
             </button>}
             <button>
-              <ImgOnBtn src={bookmarkIcon} alt="즐겨찾기 버튼" />
+              <ImgOnBtn color={FILTER_TO_ACTIVE} src={bookmarkIcon} alt="즐겨찾기 버튼" />
             </button>
           </div>
         </LowerLayout>
-      </DocListItemWrapper>
-    </Link>
+      </Link>
+    </DocListItemWrapper>
   );
 };
 
@@ -68,7 +69,7 @@ const ImgOnBtn = styled.img`
   height: 0.75rem;
   margin-left: 0.5rem;
   &:hover {
-    background-color: red;
+    filter: ${props => props.color};
   }
 `;
 

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -1,29 +1,35 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import trash from '../../assets/trash.svg';
 import bookmark from '../../assets/bookmark.svg';
 
 interface docListItemProps  {
+  id: string,
   title: string,
   lastVisited: string
   role: string
 }
 
-const DocListItem = ({title, lastVisited, role}: docListItemProps) => {
-  return (<DocListItemWrapper>
-    <Title>{title}</Title>
-    <LowerLayout>
-      <LastVisited>최근 방문일: {lastVisited}</LastVisited>
-      <div>
-        {role === 'onwer' && <button>
-          <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>
-        </button>}
-        <button>
-          <ImgOnBtn src={bookmark} alt="즐겨찾기 버튼"></ImgOnBtn>
-        </button>
-      </div>
-    </LowerLayout>
-  </DocListItemWrapper>);
+const DocListItem = ({id, title, lastVisited, role}: docListItemProps) => {
+  return (
+    <Link to={id}>
+      <DocListItemWrapper>
+        <Title>{title}</Title>
+        <LowerLayout>
+          <LastVisited>최근 방문일: {lastVisited}</LastVisited>
+          <div>
+            {role === 'onwer' && <button>
+              <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>
+            </button>}
+            <button>
+              <ImgOnBtn src={bookmark} alt="즐겨찾기 버튼"></ImgOnBtn>
+            </button>
+          </div>
+        </LowerLayout>
+      </DocListItemWrapper>
+    </Link>
+  );
 };
 
 const DocListItemWrapper = styled.div`

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import trash from '../../assets/trash.svg';
+import bookmark from '../../assets/bookmark.svg';
+
+const DocListItem = () => {
+  return (<DocListItemWrapper>
+    <Title>알고리즘 스터디 기록</Title>
+    <LowerLayout>
+      <LastVisited>최근 방문일: 2022-11-10</LastVisited>
+      <div>
+        <button>
+          <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>
+        </button>
+        <button>
+          <ImgOnBtn src={bookmark} alt="즐겨찾기 버튼"></ImgOnBtn>
+        </button>
+      </div>
+    </LowerLayout>
+  </DocListItemWrapper>);
+};
+
+const DocListItemWrapper = styled.div`
+  width: 15em;
+  height: 4.5em;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.75em;
+  border: 1px solid #B6B6B6;
+  border-radius: 10px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
+
+const Title = styled.div`
+  font-weight: 600;
+  font-size: 12px;
+  color: #222222;
+`;
+
+const LowerLayout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-top: 1.5em;
+`;
+
+const LastVisited = styled.div`
+  font-weight: 300;
+  font-size: 10px;
+  color: #A5A5A5;
+`;
+
+const ImgOnBtn = styled.img`
+  width: 0.75em;
+  height: 0.75em;
+  margin-left: 0.5em;
+`;
+
+export { DocListItem };

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -6,17 +6,18 @@ import bookmark from '../../assets/bookmark.svg';
 interface docListItemProps  {
   title: string,
   lastVisited: string
+  role: string
 }
 
-const DocListItem = ({title, lastVisited}: docListItemProps) => {
+const DocListItem = ({title, lastVisited, role}: docListItemProps) => {
   return (<DocListItemWrapper>
     <Title>{title}</Title>
     <LowerLayout>
       <LastVisited>최근 방문일: {lastVisited}</LastVisited>
       <div>
-        <button>
+        {role === 'onwer' && <button>
           <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>
-        </button>
+        </button>}
         <button>
           <ImgOnBtn src={bookmark} alt="즐겨찾기 버튼"></ImgOnBtn>
         </button>

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -3,11 +3,16 @@ import styled from 'styled-components';
 import trash from '../../assets/trash.svg';
 import bookmark from '../../assets/bookmark.svg';
 
-const DocListItem = () => {
+interface docListItemProps  {
+  title: string,
+  lastVisited: string
+}
+
+const DocListItem = ({title, lastVisited}: docListItemProps) => {
   return (<DocListItemWrapper>
-    <Title>알고리즘 스터디 기록</Title>
+    <Title>{title}</Title>
     <LowerLayout>
-      <LastVisited>최근 방문일: 2022-11-10</LastVisited>
+      <LastVisited>최근 방문일: {lastVisited}</LastVisited>
       <div>
         <button>
           <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import trash from '../../assets/trash.svg';
-import bookmark from '../../assets/bookmark.svg';
+import trashIcon from '../../assets/trash.svg';
+import bookmarkIcon from '../../assets/bookmark.svg';
 
 interface docListItemProps  {
   id: string,
@@ -20,10 +20,10 @@ const DocListItem = ({id, title, lastVisited, role}: docListItemProps) => {
           <LastVisited>최근 방문일: {lastVisited}</LastVisited>
           <div>
             {role === 'onwer' && <button>
-              <ImgOnBtn src={trash} alt="삭제하기 버튼"></ImgOnBtn>
+              <ImgOnBtn src={trashIcon} alt="삭제하기 버튼" />
             </button>}
             <button>
-              <ImgOnBtn src={bookmark} alt="즐겨찾기 버튼"></ImgOnBtn>
+              <ImgOnBtn src={bookmarkIcon} alt="즐겨찾기 버튼" />
             </button>
           </div>
         </LowerLayout>

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import trashIcon from '../../assets/trash.svg';
 import bookmarkIcon from '../../assets/bookmark.svg';
 
-interface docListItemProps  {
+interface docListItemProps {
   id: string,
   title: string,
   lastVisited: string
@@ -33,12 +33,12 @@ const DocListItem = ({id, title, lastVisited, role}: docListItemProps) => {
 };
 
 const DocListItemWrapper = styled.div`
-  width: 15em;
-  height: 4.5em;
+  width: 15rem;
+  height: 4.5rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 0.75em;
+  padding: 0.75rem;
   border: 1px solid #B6B6B6;
   border-radius: 10px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -54,7 +54,7 @@ const LowerLayout = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  padding-top: 1.5em;
+  padding-top: 1.5rem;
 `;
 
 const LastVisited = styled.div`
@@ -64,9 +64,12 @@ const LastVisited = styled.div`
 `;
 
 const ImgOnBtn = styled.img`
-  width: 0.75em;
-  height: 0.75em;
-  margin-left: 0.5em;
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-left: 0.5rem;
+  &:hover {
+    background-color: red;
+  }
 `;
 
 export { DocListItem };

--- a/frontend/src/components/docListItem/index.ts
+++ b/frontend/src/components/docListItem/index.ts
@@ -1,0 +1,1 @@
+export * from './DocListItem';

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -5,6 +5,7 @@ interface docListItemState {
   id: string
   title: string
   lastVisited: string
+  role: string,
 }
 
 const MainPage = () => {
@@ -16,9 +17,12 @@ const MainPage = () => {
       return new Promise((resolve) => {
         resolve(setDocList(() => [{id:'1234',
           title: '알고리즘 스터디 기록',
-          lastVisited: '2022-11-10'}, {id:'5678',
+          lastVisited: '2022-11-10',
+          role: 'onwer',  
+        }, {id:'5678',
           title: 'Untitled',
-          lastVisited: '2022-11-19'}]));
+          lastVisited: '2022-11-19',
+          role: 'edit'}]));
       });
     };
     fetchDocList();
@@ -27,7 +31,7 @@ const MainPage = () => {
   return (
     <div>
       {docList.length ? docList.map(doc => {
-        return <DocListItem key={doc.id} title={doc.title} lastVisited={doc.lastVisited}></DocListItem>;
+        return <DocListItem key={doc.id} title={doc.title} lastVisited={doc.lastVisited} role={doc.role}></DocListItem>;
       }) : <div>...loading</div>}
     </div>
   );

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,11 +1,34 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DocListItem } from '../components/docListItem';
 
+interface docListItemState {
+  id: string
+  title: string
+  lastVisited: string
+}
+
 const MainPage = () => {
-  
+  const [docList, setDocList] = useState<docListItemState[]>([]);
+
+  useEffect(() => {
+    const fetchDocList = async () => {
+      // TODO : request docList from API server
+      return new Promise((resolve) => {
+        resolve(setDocList(() => [{id:'1234',
+          title: '알고리즘 스터디 기록',
+          lastVisited: '2022-11-10'}, {id:'5678',
+          title: 'Untitled',
+          lastVisited: '2022-11-19'}]));
+      });
+    };
+    fetchDocList();
+  }, []);
+
   return (
     <div>
-      <DocListItem></DocListItem>;
+      {docList.length ? docList.map(doc => {
+        return <DocListItem key={doc.id} title={doc.title} lastVisited={doc.lastVisited}></DocListItem>;
+      }) : <div>...loading</div>}
     </div>
   );
 };

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -31,7 +31,7 @@ const MainPage = () => {
   return (
     <div>
       {docList.length ? docList.map(doc => {
-        return <DocListItem key={doc.id} title={doc.title} lastVisited={doc.lastVisited} role={doc.role}></DocListItem>;
+        return <DocListItem key={doc.id} id={doc.id} title={doc.title} lastVisited={doc.lastVisited} role={doc.role}></DocListItem>;
       }) : <div>...loading</div>}
     </div>
   );

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -31,7 +31,7 @@ const MainPage = () => {
   return (
     <div>
       {docList.length ? docList.map(doc => {
-        return <DocListItem key={doc.id} id={doc.id} title={doc.title} lastVisited={doc.lastVisited} role={doc.role}></DocListItem>;
+        return <DocListItem key={doc.id} id={doc.id} title={doc.title} lastVisited={doc.lastVisited} role={doc.role} />;
       }) : <div>...loading</div>}
     </div>
   );

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { DocListItem } from '../components/docListItem';
+
+const MainPage = () => {
+  
+  return (
+    <div>
+      <DocListItem></DocListItem>;
+    </div>
+  );
+};
+
+export default MainPage;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 관련 이슈
- #20 

### 변경 사항
개별 문서 아이템을 표현하기 위해서 별도의 컴포넌트로 제작했습니다. 컴포넌트는 props 로 받은 정보들을 표시합니다. Link 태그를 사용하여 문서의 id 를 URL 경로로 하는 페이지로 이동합니다. 

### 동작 확인
<img width="244" alt="스크린샷 2022-11-21 20 06 28" src="https://user-images.githubusercontent.com/31645195/203038562-d16cd8ca-1b96-469a-972b-ae58b2ab1ebd.png">

위 사진과 같이 더미 데이터에 있는 role 이라는 값이 owner 일 경우에만 삭제 버튼이 표시되도록 만들었습니다. 

### 요청사항

1. 구현하고 나니까 DocListItem 이 별도의 상태를 값으로 가지지 않는 UI 로만 존재하는 컴포넌트여서 '굳이 컴포넌트로 만들어야 하나?' 라는 생각이 드는데 여기에 대한 생각이 궁금합니다. 

2. CSS 부분을 보시면 단위를 em 으로 설정했습니다. 글씨 크기에 따라서 padding 이나 width / height 가 가변적으로 변하면 좋겠다고 생각했습니다. 하지만 실제 스타일을 조정하면서 em 으로 계산하는 것이 많이 헷갈렸습니다. em 대신 rem 을 사용하는 것에 대한 의견이 궁금합니다. 
