### PR TITLE
siteId 비교 로직 추가 

### DIFF
--- a/frontend/src/core/crdt-linear/char.ts
+++ b/frontend/src/core/crdt-linear/char.ts
@@ -3,14 +3,11 @@ export default class Char {
 
   siteId: string;
 
-  counter: number;
-
   value: string;
 
-  constructor(index: CRDTIndex, siteId: string, value: string, counter: number) {
+  constructor(index: CRDTIndex, siteId: string, value: string) {
     this.index = index;
     this.siteId = siteId;
-    this.counter = counter;
     this.value = value;
   }
 }

--- a/frontend/src/core/crdt-linear/char.ts
+++ b/frontend/src/core/crdt-linear/char.ts
@@ -3,11 +3,14 @@ export default class Char {
 
   siteId: string;
 
+  counter: number;
+
   value: string;
 
-  constructor(index: CRDTIndex, siteId: string, value: string) {
+  constructor(index: CRDTIndex, siteId: string, value: string, counter: number) {
     this.index = index;
     this.siteId = siteId;
+    this.counter = counter;
     this.value = value;
   }
 }

--- a/frontend/src/core/crdt-linear/crdt.test.ts
+++ b/frontend/src/core/crdt-linear/crdt.test.ts
@@ -107,15 +107,13 @@ describe('searchIndex() Test:', () => {
   });
 
   it('1. remoteInsert된 Char의 인덱스가 기존 struct 사이에 존재하는 경우', () => {
-    expect(crdt.searchInsertIndex(new Char([0, 5], '123', 'D'))).toEqual(1);
+    expect(crdt.searchInsertIndex(new Char([0, 7, 5], '123', 'D', 4))).toEqual(1);
   });
   it('2. crdt struct 인덱스를 초과하는 Char 입력 (맨 뒤에 입력)', () => {
-    expect(crdt.searchInsertIndex(new Char([9999, 5, 5], '123', 'D'))).toEqual(
-      3
-    );
+    expect(crdt.searchInsertIndex(new Char([9999, 5, 5], '123', 'D', 5))).toEqual(3);
   });
   it('3. crdt struct 인덱스를 초과하는 Char 입력 (맨 앞에 입력)', () => {
-    expect(crdt.searchInsertIndex(new Char([-1, 5, 5], '123', 'D'))).toEqual(0);
+    expect(crdt.searchInsertIndex(new Char([-1, 5, 5], '123', 'D', 6))).toEqual(0);
   });
 });
 
@@ -132,34 +130,34 @@ describe('remoteInsert() Test:', () => {
   let editor: CodeMirror.Editor;
 
   it('1. remoteInsert된 Char의 인덱스가 기존 struct 사이에 존재하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 7], '123', 'D')], editor);
+    crdt.remoteInsert([new Char([0, 7], '123', 'D', 3)], editor);
     expect(crdt.toString()).toEqual('ADBC');
   });
   it('2. remoteInsert : 맨 앞에 입력받는 경우', () => {
-    crdt.remoteInsert([new Char([0, 2, 5], '123', 'D')], editor);
+    crdt.remoteInsert([new Char([0, 2, 5], '123', 'D', 4)], editor);
     expect(crdt.toString()).toEqual('DABC');
   });
   it('3. remoteInsert : 맨 뒤에 입력받는 경우', () => {
-    crdt.remoteInsert([new Char([9999, 5], '123', 'D')], editor);
+    crdt.remoteInsert([new Char([9999, 5], '123', 'D', 5)], editor);
     expect(crdt.toString()).toEqual('ABCD');
   });
   it('4. remoteInsert : 오류 케이스 1', () => {
     crdt.struct = [];
-    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5],'abc','s')], editor);
-    crdt.remoteInsert([new Char([0,7,5],'abc','m')], editor);
-    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,5,8,3,6,6,6,3,6,5,7,6,5,5,6,6,2,9,7,3,4,1,1,3,8,1,2,4,4,6,5,9,4,2,3,8,2,8,1,2,5],'abc','e')], editor);
+    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5],'abc','s', 6)], editor);
+    crdt.remoteInsert([new Char([0,7,5],'abc','m', 7)], editor);
+    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,5,8,3,6,6,6,3,6,5,7,6,5,5,6,6,2,9,7,3,4,1,1,3,8,1,2,4,4,6,5,9,4,2,3,8,2,8,1,2,5],'abc','e', 8)], editor);
     expect(crdt.toString()).toEqual('esm');
   });
   it('5. remoteInsert : 여러 개를 맨 뒤에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([9999, 5], '123', 'D'), new Char([9999, 7, 5], '123', 'E'), new Char([9999, 9], '123', 'F')], editor);
+    crdt.remoteInsert([new Char([9999, 5], '123', 'D', 3), new Char([9999, 7, 5], '123', 'E', 4), new Char([9999, 9], '123', 'F', 5)], editor);
     expect(crdt.toString()).toEqual('ABCDEF');
   });
   it('5. remoteInsert : 여러 개 사이에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 7], '123', 'D'), new Char([0, 8], '123', 'E'), new Char([0, 9], '123', 'F')], editor);
+    crdt.remoteInsert([new Char([0, 7], '123', 'D',3 ), new Char([0, 8], '123', 'E', 4), new Char([0, 9], '123', 'F', 5)], editor);
     expect(crdt.toString()).toEqual('ADEFBC');
   });
   it('5. remoteInsert : 여러 개 맨 앞에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 1], '123', 'D'), new Char([0, 2], '123', 'E'), new Char([0, 3], '123', 'F')], editor);
+    crdt.remoteInsert([new Char([0, 1], '123', 'D', 3), new Char([0, 2], '123', 'E', 4), new Char([0, 3], '123', 'F', 5)], editor);
     expect(crdt.toString()).toEqual('DEFABC');
   });
 });
@@ -192,18 +190,55 @@ describe('convertCRDTIndex() Test:', () => {
   });
 
   it('1. [1, 2, 3] - [1, 2, 4]', () => {
-    expect(crdt.compareCRDTIndex([1, 2, 3], [1, 2, 4])).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a', 1), new Char([1, 2, 4], '124', 'b', 2))).toEqual(false);
   });
   
   it('2. [1, 2] - [1, 2, 4]', () => {
-    expect(crdt.compareCRDTIndex([1, 2], [1, 2, 4])).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([1, 2], '123', 'a', 2), new Char([1, 2, 4], '123', 'b', 3))).toEqual(false);
   });
 
   it('3. [1, 2, 3] - [1, 2]', () => {
-    expect(crdt.compareCRDTIndex([1, 2, 3], [1, 2])).toEqual(true);
+    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a', 1), new Char([1, 2], '124', 'b', 2))).toEqual(true);
   });
   
   it('4. [0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5] - [0,7,5]',() => {
-    expect(crdt.compareCRDTIndex([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5], [0, 7, 5])).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5], '123', 'a', 1), new Char([0, 7, 5], '124', 'b', 2))).toEqual(false);
   });
+});
+
+describe('중복 인덱스 테스트 Test:', () => {
+  let crdt1: CRDT;
+  let crdt2: CRDT;
+  
+  beforeEach(() => {
+    crdt1 = new CRDT();
+    crdt2 = new CRDT();
+  });
+
+  let editor: CodeMirror.Editor;
+
+  it('같은 인덱스를 가진 두 Char를 순서를 바꿔 Insert 테스트 (교환법칙 성립 확인)', () => {
+
+    crdt1.remoteInsert([new Char([0,5], '456', 'B', 0)], editor);
+    crdt1.remoteInsert([new Char([0,5], '123', 'A', 0)], editor);
+
+    crdt2.remoteInsert([new Char([0,5], '123', 'A', 0)], editor);
+    crdt2.remoteInsert([new Char([0,5], '456', 'B', 0)], editor);
+
+    expect(crdt1.toString()).toEqual('AB');
+    expect(crdt2.toString()).toEqual('AB');
+    expect(crdt1.struct).toEqual(crdt2.struct);
+  });
+
+  it('2. 두 인덱스가 같고, originChar의 siteID가 더 큰 경우', () => {
+    const originChar = new Char([1, 2, 4], 'b', '', 2);
+    const insertedChar = new Char([1, 2, 4], 'a', '', 3);
+    expect(crdt1.compareCRDTIndex(originChar, insertedChar)).toEqual(true);
+  }); 
+
+  it('3. 두 인덱스가 같고, originChar의 siteID가 더 작은 경우', () => {
+    const originChar = new Char([1, 2, 4], 'a', '', 2);
+    const insertedChar = new Char([1, 2, 4], 'b', '', 3);
+    expect(crdt1.compareCRDTIndex(originChar, insertedChar)).toEqual(false);
+  }); 
 });

--- a/frontend/src/core/crdt-linear/crdt.test.ts
+++ b/frontend/src/core/crdt-linear/crdt.test.ts
@@ -107,13 +107,13 @@ describe('searchIndex() Test:', () => {
   });
 
   it('1. remoteInsert된 Char의 인덱스가 기존 struct 사이에 존재하는 경우', () => {
-    expect(crdt.searchInsertIndex(new Char([0, 7, 5], '123', 'D', 4))).toEqual(1);
+    expect(crdt.searchInsertIndex(new Char([0, 7, 5], '123', 'D'))).toEqual(1);
   });
   it('2. crdt struct 인덱스를 초과하는 Char 입력 (맨 뒤에 입력)', () => {
-    expect(crdt.searchInsertIndex(new Char([9999, 5, 5], '123', 'D', 5))).toEqual(3);
+    expect(crdt.searchInsertIndex(new Char([9999, 5, 5], '123', 'D'))).toEqual(3);
   });
   it('3. crdt struct 인덱스를 초과하는 Char 입력 (맨 앞에 입력)', () => {
-    expect(crdt.searchInsertIndex(new Char([-1, 5, 5], '123', 'D', 6))).toEqual(0);
+    expect(crdt.searchInsertIndex(new Char([-1, 5, 5], '123', 'D'))).toEqual(0);
   });
 });
 
@@ -130,34 +130,34 @@ describe('remoteInsert() Test:', () => {
   let editor: CodeMirror.Editor;
 
   it('1. remoteInsert된 Char의 인덱스가 기존 struct 사이에 존재하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 7], '123', 'D', 3)], editor);
+    crdt.remoteInsert([new Char([0, 7], '123', 'D')], editor);
     expect(crdt.toString()).toEqual('ADBC');
   });
   it('2. remoteInsert : 맨 앞에 입력받는 경우', () => {
-    crdt.remoteInsert([new Char([0, 2, 5], '123', 'D', 4)], editor);
+    crdt.remoteInsert([new Char([0, 2, 5], '123', 'D')], editor);
     expect(crdt.toString()).toEqual('DABC');
   });
   it('3. remoteInsert : 맨 뒤에 입력받는 경우', () => {
-    crdt.remoteInsert([new Char([9999, 5], '123', 'D', 5)], editor);
+    crdt.remoteInsert([new Char([9999, 5], '123', 'D')], editor);
     expect(crdt.toString()).toEqual('ABCD');
   });
   it('4. remoteInsert : 오류 케이스 1', () => {
     crdt.struct = [];
-    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5],'abc','s', 6)], editor);
-    crdt.remoteInsert([new Char([0,7,5],'abc','m', 7)], editor);
-    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,5,8,3,6,6,6,3,6,5,7,6,5,5,6,6,2,9,7,3,4,1,1,3,8,1,2,4,4,6,5,9,4,2,3,8,2,8,1,2,5],'abc','e', 8)], editor);
+    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5],'abc','s')], editor);
+    crdt.remoteInsert([new Char([0,7,5],'abc','m')], editor);
+    crdt.remoteInsert([new Char([0,7,4,9,9,9,9,9,9,9,9,5,8,3,6,6,6,3,6,5,7,6,5,5,6,6,2,9,7,3,4,1,1,3,8,1,2,4,4,6,5,9,4,2,3,8,2,8,1,2,5],'abc','e')], editor);
     expect(crdt.toString()).toEqual('esm');
   });
   it('5. remoteInsert : 여러 개를 맨 뒤에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([9999, 5], '123', 'D', 3), new Char([9999, 7, 5], '123', 'E', 4), new Char([9999, 9], '123', 'F', 5)], editor);
+    crdt.remoteInsert([new Char([9999, 5], '123', 'D'), new Char([9999, 7, 5], '123', 'E'), new Char([9999, 9], '123', 'F')], editor);
     expect(crdt.toString()).toEqual('ABCDEF');
   });
   it('5. remoteInsert : 여러 개 사이에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 7], '123', 'D',3 ), new Char([0, 8], '123', 'E', 4), new Char([0, 9], '123', 'F', 5)], editor);
+    crdt.remoteInsert([new Char([0, 7], '123', 'D'), new Char([0, 8], '123', 'E'), new Char([0, 9], '123', 'F')], editor);
     expect(crdt.toString()).toEqual('ADEFBC');
   });
   it('5. remoteInsert : 여러 개 맨 앞에 입력하는 경우', () => {
-    crdt.remoteInsert([new Char([0, 1], '123', 'D', 3), new Char([0, 2], '123', 'E', 4), new Char([0, 3], '123', 'F', 5)], editor);
+    crdt.remoteInsert([new Char([0, 2], '123', 'D'), new Char([0, 3], '123', 'E'), new Char([0, 4], '123', 'F')], editor);
     expect(crdt.toString()).toEqual('DEFABC');
   });
 });
@@ -190,19 +190,19 @@ describe('convertCRDTIndex() Test:', () => {
   });
 
   it('1. [1, 2, 3] - [1, 2, 4]', () => {
-    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a', 1), new Char([1, 2, 4], '124', 'b', 2))).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a'), new Char([1, 2, 4], '124', 'b'))).toEqual(false);
   });
   
   it('2. [1, 2] - [1, 2, 4]', () => {
-    expect(crdt.compareCRDTIndex(new Char([1, 2], '123', 'a', 2), new Char([1, 2, 4], '123', 'b', 3))).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([1, 2], '123', 'a'), new Char([1, 2, 4], '123', 'b'))).toEqual(false);
   });
 
   it('3. [1, 2, 3] - [1, 2]', () => {
-    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a', 1), new Char([1, 2], '124', 'b', 2))).toEqual(true);
+    expect(crdt.compareCRDTIndex(new Char([1, 2, 3], '123', 'a'), new Char([1, 2], '124', 'b'))).toEqual(true);
   });
   
   it('4. [0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5] - [0,7,5]',() => {
-    expect(crdt.compareCRDTIndex(new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5], '123', 'a', 1), new Char([0, 7, 5], '124', 'b', 2))).toEqual(false);
+    expect(crdt.compareCRDTIndex(new Char([0,7,4,9,9,9,9,9,9,9,9,9,9,9,9,9,9,1,6,7,3,3,2,7,3,1,5,3,1,1,3,2,5,9,4,6,8,2,2,7,6,2,4,8,9,3,1,8,8,4,7,6,5,6,2,5], '123', 'a'), new Char([0, 7, 5], '124', 'b'))).toEqual(false);
   });
 });
 
@@ -219,11 +219,11 @@ describe('중복 인덱스 테스트 Test:', () => {
 
   it('같은 인덱스를 가진 두 Char를 순서를 바꿔 Insert 테스트 (교환법칙 성립 확인)', () => {
 
-    crdt1.remoteInsert([new Char([0,5], '456', 'B', 0)], editor);
-    crdt1.remoteInsert([new Char([0,5], '123', 'A', 0)], editor);
+    crdt1.remoteInsert([new Char([0,5], '456', 'B')], editor);
+    crdt1.remoteInsert([new Char([0,5], '123', 'A')], editor);
 
-    crdt2.remoteInsert([new Char([0,5], '123', 'A', 0)], editor);
-    crdt2.remoteInsert([new Char([0,5], '456', 'B', 0)], editor);
+    crdt2.remoteInsert([new Char([0,5], '123', 'A')], editor);
+    crdt2.remoteInsert([new Char([0,5], '456', 'B')], editor);
 
     expect(crdt1.toString()).toEqual('AB');
     expect(crdt2.toString()).toEqual('AB');
@@ -231,14 +231,14 @@ describe('중복 인덱스 테스트 Test:', () => {
   });
 
   it('2. 두 인덱스가 같고, originChar의 siteID가 더 큰 경우', () => {
-    const originChar = new Char([1, 2, 4], 'b', '', 2);
-    const insertedChar = new Char([1, 2, 4], 'a', '', 3);
+    const originChar = new Char([1, 2, 4], 'b', '');
+    const insertedChar = new Char([1, 2, 4], 'a', '');
     expect(crdt1.compareCRDTIndex(originChar, insertedChar)).toEqual(true);
   }); 
 
   it('3. 두 인덱스가 같고, originChar의 siteID가 더 작은 경우', () => {
-    const originChar = new Char([1, 2, 4], 'a', '', 2);
-    const insertedChar = new Char([1, 2, 4], 'b', '', 3);
+    const originChar = new Char([1, 2, 4], 'a', '');
+    const insertedChar = new Char([1, 2, 4], 'b', '');
     expect(crdt1.compareCRDTIndex(originChar, insertedChar)).toEqual(false);
   }); 
 });

--- a/frontend/src/core/crdt-linear/crdt.ts
+++ b/frontend/src/core/crdt-linear/crdt.ts
@@ -15,30 +15,23 @@ class CRDT {
     this.struct = [];
   }
 
-  increaseCounter() {
-    this.localCounter++;
-  }
-
   localInsertRange(index: number, value: string): Char[] {
     return value.split('').map((c, i)=> this.localInsert(index+i, c));
   }
   
   localInsert(index: number, value: string) : Char {
-    this.increaseCounter();
     const insertedChar = this.generateChar(index, value);
     this.struct.splice(index, 0, insertedChar);
     return insertedChar;
   }
 
   localDelete(startIndex: number, endIndex: number) : Char[] {
-    this.increaseCounter();
     const deletedChars = this.struct.splice(startIndex, endIndex - startIndex);
     return deletedChars;
   }
 
   remoteInsert(chars: Char[], editor: CodeMirror.Editor) {
     // binary?
-    this.increaseCounter();
     const index = this.searchInsertIndex(chars[0]);
     this.struct.splice(index, 0, ...chars);
 
@@ -53,7 +46,6 @@ class CRDT {
   }
 
   remoteDelete(char: Char, doc: CodeMirror.Doc) {
-    this.increaseCounter();
     const index = this.searchDeleteIndex(char);
     if (index === -1) {
       return;
@@ -106,7 +98,7 @@ class CRDT {
     const endIndex = this.struct[index] ? this.struct[index].index : [];
     const newIndex = this.generateIndex(startIndex, endIndex);
 
-    return new Char(newIndex, this.siteId, value, this.localCounter);
+    return new Char(newIndex, this.siteId, value);
   }
 
   generateIndex(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
#36 

### 변경 사항
CRDTIndex 를 비교할 때, 두 Char 의 인덱스 길이가 같을 경우 sideId 가 작은 Char 를 앞에 배치합니다.
Char 객체에 counter 를 사용하지 않게 되면서 CRDT 와 테스트 코드에서 관련 로직을 삭제합니다.

### 동작 확인

![스크린샷 2022-11-30 15 14 41](https://user-images.githubusercontent.com/31645195/204721647-057a6820-f518-4424-8bdf-c4e686685b32.png)

새롭게 작성한 테스트 코드를 모두 통과합니다!!