### PR TITLE
fix: 사파리 크로스 브라우징 이슈 해결

### DIFF
--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -27,6 +27,7 @@ const Editor = () => {
     }
 
     editor.setValue(crdt.toString());
+    editor.focus();
     
     socket.on('remote-insert', (data) => {
       crdt.remoteInsert(data, editor);
@@ -91,10 +92,22 @@ const Editor = () => {
   }, [editor]);
   
   const editorOptions = useMemo(() => {
-    return {
-      autofocus: true,
-      spellChecker: false
+    const opts = {
+      spellChecker: false,
+      placeholder: 'Write document here and share!',
+      toolbar: [
+        'side-by-side',
+        'preview',
+        'fullscreen',
+      ],
+      unorderedListStyle: '-',
+      status: false,
+      shortcuts: {
+        toggleUnorderedList: null,
+      },
     } as SimpleMDE.Options;
+
+    return opts;
   }, []);
 
   const getCmInstanceCallback = useCallback((cm: CodeMirror.Editor) => {

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -51,13 +51,7 @@ const Editor = () => {
         char = crdt.localInsertRange(fromIdx, content);
         eventName = 'local-insert';
         break;
-      
-      
       case '+input':
-        char = crdt.localInsertRange(fromIdx, content);
-        eventName = 'local-insert';
-        break;
-
       case '*compose': 
         char = crdt.localDelete(fromIdx, toIdx);
         socket.emit('local-delete', char);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
#39 

### 변경 사항
에디터 페이지에서 CodeMirror 에서 제공하는 마크다운 문법 버튼을 숨겼습니다.
사파리에서 한글 입력 시 compose 이벤트가 아니라 input 이벤트가 발생하여 관련 switch-case 문을 수정했습니다. 

### 동작 확인

![스크린샷 2022-12-01 10 32 09](https://user-images.githubusercontent.com/31645195/204944314-16ae0329-e3a8-4fba-ae09-028298e36cb4.png)

좌측 사파리와 우측 크롬에서 모두 정상 작동합니다. 