### PR TITLE
마크다운 프리뷰 기능 추가 및 의존성 변경, normalize css로 교체

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "@types/socket.io-client": "^3.0.0",
-        "easymde": "^2.18.0",
+        "easymde": "^2.16.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
@@ -3873,9 +3873,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/marked": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
-      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
+      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -6608,15 +6608,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "node_modules/easymde": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.18.0.tgz",
-      "integrity": "sha512-IxVVUxNWIoXLeqtBU4BLc+eS/ScYhT1Dcb6yF5Wchoj1iXAV+TIIDWx+NCaZhY7RcSHqDPKllbYq7nwGKILnoA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.16.0.tgz",
+      "integrity": "sha512-RNeb+JGCBfbhlyuwGfBqImt3lWeb8sy/3AH7O7IRk0N6YMwVXIKAam5Ph2H4cbjHl1mkAJ/ssxqbytLQvZsISA==",
       "dependencies": {
         "@types/codemirror": "^5.60.4",
-        "@types/marked": "^4.0.7",
+        "@types/marked": "^3.0.1",
         "codemirror": "^5.63.1",
         "codemirror-spell-checker": "1.1.2",
-        "marked": "^4.1.0"
+        "marked": "^3.0.4"
       }
     },
     "node_modules/ee-first": {
@@ -11754,11 +11754,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
       "bin": {
-        "marked": "bin/marked.js"
+        "marked": "bin/marked"
       },
       "engines": {
         "node": ">= 12"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "recoil": "^0.7.6",
         "socket.io-client": "^4.5.4",
         "styled-components": "^5.3.6",
-        "styled-reset": "^4.4.2",
+        "styled-normalize": "^8.0.7",
         "typescript": "^4.8.4",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
@@ -15521,19 +15521,12 @@
         "react-is": ">= 16.8.0"
       }
     },
-    "node_modules/styled-reset": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
-      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/zacanger"
-      },
+    "node_modules/styled-normalize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
+      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ==",
       "peerDependencies": {
-        "styled-components": ">=4.0.0 || >=5.0.0"
+        "styled-components": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/stylehacks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "@types/socket.io-client": "^3.0.0",
-    "easymde": "^2.18.0",
+    "easymde": "^2.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "recoil": "^0.7.6",
     "socket.io-client": "^4.5.4",
     "styled-components": "^5.3.6",
-    "styled-reset": "^4.4.2",
+    "styled-normalize": "^8.0.7",
     "typescript": "^4.8.4",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"

--- a/frontend/src/GlobalStyles.ts
+++ b/frontend/src/GlobalStyles.ts
@@ -1,8 +1,8 @@
 import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
+import { normalize } from 'styled-normalize';
 
 const GlobalStyles = createGlobalStyle` 
-  ${reset}
+  ${normalize}
     body {
         font-family: 'Inter', sans-serif;
     } 

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {useParams} from 'react-router-dom';
 import SimpleMDEReact from 'react-simplemde-editor';
 import SimpleMDE from 'easymde';
 import CodeMirror from 'codemirror';
 import 'easymde/dist/easymde.min.css';
-import { crdt } from '../core/crdt-linear-ll/crdt';
+import {crdt} from '../core/crdt-linear-ll/crdt';
 import socket from '../core/sockets/sockets';
 
 const Editor = () => {
@@ -88,7 +88,7 @@ const Editor = () => {
   }, [editor]);
   
   const editorOptions = useMemo(() => {
-    const opts = {
+    return {
       spellChecker: false,
       placeholder: 'Write document here and share!',
       toolbar: [
@@ -102,8 +102,6 @@ const Editor = () => {
         toggleUnorderedList: null,
       },
     } as SimpleMDE.Options;
-
-    return opts;
   }, []);
 
   const getCmInstanceCallback = useCallback((cm: CodeMirror.Editor) => {
@@ -112,7 +110,7 @@ const Editor = () => {
 
   return (
     <>
-      {isLoading === true ? <div>로딩중...</div> : (<SimpleMDEReact
+      {isLoading ? <div>로딩중...</div> : (<SimpleMDEReact
         options={editorOptions}
         getCodemirrorInstance={getCmInstanceCallback}
         onCompositionStart={() => console.log('COMPOSITION START') }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #46 
- #48 
- #49 

### 변경 사항
SimpleMDE에서 마크다운 프리뷰가 제대로 작동하지 않는 버그를 수정하였습니다.
SimpleMDE Issue를 통해 트러블 슈팅을 찾고, easymde 버전을 2.16.0으로 다운그레이드 하였습니다. 

또한 현재 사용하고 있는 reset.css가 마크다운이 변환되는 HTML 태그의 기본 스타일도 다 없애버려 렌더링이 제대로 되지 않는 문제가 발생하여 수정하였습니다. 

현재 정상 동작하는 것을 확인했습니다 ^^

### 동작 확인
![image](https://user-images.githubusercontent.com/78531103/205332036-798beb20-57e3-4550-85f6-08d156ae2939.png)
