### PR TITLE
React lazy 적용

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import GlobalStyles from './GlobalStyles';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import DocumentPage from './pages/DocumentPage';
-import LandingPage from './pages/LandingPage';
-import MainPage from './pages/MainPage';
+
+const LandingPage = lazy(() => import('./pages/LandingPage'));
+const MainPage = lazy(() => import('./pages/MainPage'));
+const DocumentPage = lazy(() => import('./pages/DocumentPage'));
 
 const Router = () => {
   return (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #66 

### 변경 사항
라우트가 적용된 Router.tsx 에서 성능 향상을 위해 lazy 를 적용합니다.
<App /> 컴포넌트를 로딩할 때 모든 페이지 컴포넌트를 불러오는 것이 아니라 사용자가 페이지를 이동할 때마다 필요한 페이지 컴포넌트를 불러오게 됩니다. 

### 동작 확인

#### 적용 전 
![스크린샷 2022-12-07 02 03 06](https://user-images.githubusercontent.com/31645195/205976382-e011ebc1-376d-47cb-b654-58ad41554310.png)

기존에는 말이죠.
로컬에서 LightHouse 를 테스트해보면 우리가 정한 LCP 마지노선 점수인 0.75 를 넘지 못했어요.
그래서 Warning 메세지를 마주했답니다.

#### 적용 후 
<img width="744" alt="스크린샷 2022-12-07 02 05 32" src="https://user-images.githubusercontent.com/31645195/205976395-3b166287-2637-4f8a-a813-c973af2c5fe0.png">
적용하고 나서는 가뿐히 통과합니다. 

![스크린샷 2022-12-07 01 58 49](https://user-images.githubusercontent.com/31645195/205974846-90bc6618-8d10-4de9-b849-851a8bb35b4b.png)

성능 확실하네요. 👍