### PR TITLE
fallback UI 로 사용할 Spinner 컴포넌트 구현

### DIFF
--- a/frontend/src/components/docListContainer/DocListContainer.tsx
+++ b/frontend/src/components/docListContainer/DocListContainer.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { DocList } from '../docList';
+import { Spinner } from '../spinner/Spinner';
 import { fetchDataFromPath } from '../../utils/fetchBeforeRender';
 
 const response: { read(): any;} = fetchDataFromPath('/document/main');
@@ -7,7 +8,7 @@ const response: { read(): any;} = fetchDataFromPath('/document/main');
 const DocListContainer = () => {
 
   return (
-    <Suspense fallback={<div>loading.......</div>}>
+    <Suspense fallback={<Spinner />}>
       <DocList response={response}/>
     </Suspense>
   );

--- a/frontend/src/components/spinner/Spinner.tsx
+++ b/frontend/src/components/spinner/Spinner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const Spinner = () => {
+  return (
+    <SpinnerWrapper>
+      <LoadingCircle />
+    </SpinnerWrapper>
+  );
+};
+
+const SpinnerWrapper = styled.div`
+  height: 70%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const rotate = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const LoadingCircle = styled.div`
+  width: 5%;
+  aspect-ratio: 1 / 1;
+  border: 0.5rem dotted #bbb;
+  border-top: 0.5rem dotted #fff;
+  border-radius: 50px;
+  animation: ${rotate} 1.2s cubic-bezier(0.01, 1.05, 1,-0.05) infinite;
+`;
+
+export { Spinner };

--- a/frontend/src/components/spinner/index.ts
+++ b/frontend/src/components/spinner/index.ts
@@ -1,0 +1,1 @@
+export * from './Spinner';


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #60 

### 변경 사항
데이터를 불러오는 도중에 Suspense 에서 사용할 fallback UI 를 구현했습니다. 범용적으로 사용해보기 위해서 Wrapper 는 부모의 높이 값에 따라 달라지고 circle 은 너비 값에 따라 달라지도록 합니다.

### 동작 확인

#### 넓은 화면에서 적용할 때 
![화면-기록-2022-12-07-14 25 11](https://user-images.githubusercontent.com/31645195/206096793-d0d9c9cc-37a2-46b3-a551-673337b67bfe.gif)


#### 작은 화면에서 적용할 때 
![화면-기록-2022-12-07-14 26 33](https://user-images.githubusercontent.com/31645195/206096805-3a12d113-5ffe-4fe1-a406-944a387ad66d.gif)


원래는 Big 이랑 Small 로 두 가지 버전으로 만들까 했는데 맨파워 낭비가 아닐까 생각하여 하나로 구현했습니다. 
스타일에 상대값을 적용하여 Spinner 가 위치한 컴포넌트의 크기에 따라서 디자인이 바뀝니다. 
일단 Suspense 에 적용하고 디자인은 일괄 적용하면 좋을 것 같아서 만들었는데
의견이 어떠신지요~?

저는 만들고 보니까 쪼꼬미한게 귀여워서 
생각보다 괜찮을지도? 라는 생각을 했네요.
의견 받습니다 🙂
(첨부하고 보니까 프레임 드랍이 있는데 비디오 문제 같아용)