### PR TITLE
MSW Mocking 으로 프로필 / 문서 API 작업

### DIFF
--- a/frontend/src/components/docListContainer/DocListContainer.tsx
+++ b/frontend/src/components/docListContainer/DocListContainer.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { DocList } from '../docList';
 import { fetchDataFromPath } from '../../utils/fetchBeforeRender';
 
-const response: { read(): any;} = fetchDataFromPath('/document/main');
+const response = fetchDataFromPath('/document/main');
 
 const DocListContainer = () => {
 

--- a/frontend/src/mocks/dummy/docList.ts
+++ b/frontend/src/mocks/dummy/docList.ts
@@ -1,0 +1,24 @@
+import { v1 as uuidv1 } from 'uuid';
+
+interface roleEnumObj {
+  [key : number] : string,
+}
+
+const roleEnumMock: roleEnumObj = {
+  1: 'view',
+  2: 'edit',
+  3: 'onwer',
+};
+
+const createDocumentList = (counts: number): DocListItem[] => {
+  return Array(counts).fill(null).map(_ => { 
+    return {
+      id: uuidv1(),
+      title: Math.random().toFixed(4).slice(2).toString(),
+      lastVisited: '2022-12-01',
+      role: roleEnumMock[Math.floor((Math.random() * 3 + 1))],
+    };
+  });
+};
+
+export default createDocumentList;

--- a/frontend/src/mocks/dummy/document.ts
+++ b/frontend/src/mocks/dummy/document.ts
@@ -1,0 +1,7 @@
+import { v1 as uuidv1 } from 'uuid';
+
+const createDocumentId = () => {
+  return uuidv1();
+};
+
+export default createDocumentId;

--- a/frontend/src/mocks/dummy/userProfile.ts
+++ b/frontend/src/mocks/dummy/userProfile.ts
@@ -1,0 +1,12 @@
+import { v1 as uuidv1 } from 'uuid';
+
+const createUserProfile = (counts: number): UserProfile[] => {
+  return Array(counts).fill(null).map(_ => { 
+    return {
+      profileImgURL: 'https://picsum.photos/200',
+      userName: uuidv1().slice(0, 8)
+    };
+  });
+};
+
+export default createUserProfile;

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -1,21 +1,25 @@
 import { rest } from 'msw';
 import createDocumentList from './dummy/docList';
+import createUserProfile from './dummy/userProfile';
 
 interface generateEnumObj {
-  [key : string] : (counts: number) => DocListItem[];
+  [key : string] : (counts: number) => DocListItem[] | UserProfile[];
 }
 
 const generateFunc: generateEnumObj = {
   'docList' : createDocumentList,
+  'userProfile' : createUserProfile,
 };
 
 const generateDummy = (target: string, counts: number) => {
   return generateFunc[target](counts);
 };
 
-
 export const handler = [
   rest.get('/document/main', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(generateDummy('docList', 30)));
   }),
+  rest.get('/user/profile', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(generateDummy('userProfile', 1)[0]));
+  })
 ];

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -1,17 +1,19 @@
 import { rest } from 'msw';
 import createDocumentList from './dummy/docList';
+import createDocumentId from './dummy/document';
 import createUserProfile from './dummy/userProfile';
 
 interface generateEnumObj {
-  [key : string] : (counts: number) => DocListItem[] | UserProfile[];
+  [key : string] : (counts: number) => DocListItem[] | UserProfile[] | string;
 }
 
 const generateFunc: generateEnumObj = {
   'docList' : createDocumentList,
+  'document': createDocumentId, 
   'userProfile' : createUserProfile,
 };
 
-const generateDummy = (target: string, counts: number) => {
+const generateDummy = (target: string, counts = 1) => {
   return generateFunc[target](counts);
 };
 
@@ -19,7 +21,10 @@ export const handler = [
   rest.get('/document/main', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(generateDummy('docList', 30)));
   }),
+  rest.get('/document/new', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(generateDummy('document')));
+  }),
   rest.get('/user/profile', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(generateDummy('userProfile', 1)[0]));
-  })
+    return res(ctx.status(200), ctx.json(generateDummy('userProfile')[0]));
+  }),
 ];

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -1,29 +1,21 @@
 import { rest } from 'msw';
+import createDocumentList from './dummy/docList';
 
-const docList: DocListItem[] = [{id:'1234',
-  title: '알고리즘 스터디 기록',
-  lastVisited: '2022-11-10',
-  role: 'onwer',  
-}, {id:'5678',
-  title: 'Untitled',
-  lastVisited: '2022-11-19',
-  role: 'edit'
-}, {id:'9012',
-  title: 'Untitled',
-  lastVisited: '2022-11-19',
-  role: 'edit'
-}, {id:'3456',
-  title: 'Untitled',
-  lastVisited: '2022-11-19',
-  role: 'edit'
-}, {id:'7890',
-  title: 'Untitled',
-  lastVisited: '2022-11-19',
-  role: 'edit'
-}];
+interface generateEnumObj {
+  [key : string] : (counts: number) => DocListItem[];
+}
+
+const generateFunc: generateEnumObj = {
+  'docList' : createDocumentList,
+};
+
+const generateDummy = (target: string, counts: number) => {
+  return generateFunc[target](counts);
+};
+
 
 export const handler = [
   rest.get('/document/main', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(docList));
+    return res(ctx.status(200), ctx.json(generateDummy('docList', 30)));
   }),
 ];

--- a/frontend/src/types/userProfile.d.ts
+++ b/frontend/src/types/userProfile.d.ts
@@ -1,0 +1,4 @@
+declare type UserProfile = {
+  profileImgURL: string,
+  userName: string,
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #22 
- #40 

### 변경 사항
MSW 를 사용하여 사용자 프로필 정보를 가져오는 API 를 모킹합니다. 
추가로 새로운 문서를 생성할 때 서버로부터 생성된 문서의 ID (uuid) 를 반환 받습니다. 

### 동작 확인

#### 프로필 정보
<img width="1230" alt="스크린샷 2022-12-07 16 23 27" src="https://user-images.githubusercontent.com/31645195/206114491-ac5f8327-2366-4fe9-904a-a502e08db0de.png">

#### uuid 생성
<img width="358" alt="스크린샷 2022-12-07 16 25 19" src="https://user-images.githubusercontent.com/31645195/206114833-0e2c89fe-3346-41cc-b5e5-4cc9143384f8.png">

프로필 정보가 렌더링되고 테스트로 만든 버튼에 클릭 이벤트를 추가하여 uuid 를 콘솔에 프린트하는 것을 확인했습니다. 
실제 컴포넌트에서 테스트할 예정입니다.
