### PR TITLE
에디터 페이지 헤더 추가, title 수정 관련 소켓 이벤트 추가, 전역 상태 추가

### DIFF
--- a/backend/socket/index.ts
+++ b/backend/socket/index.ts
@@ -10,30 +10,34 @@ const io = new Server(httpServer, { cors: { origin: '*' } });
 const crdts = {};
 // 클라이언트 목록, 룸 목록 관리
 
-io.on('connection', client => {
-  client.on('joinroom', (room)=>{
+io.on('connection', (client) => {
+  client.on('joinroom', (room) => {
     if (!crdts.hasOwnProperty(room)) {
       crdts[room] = new CRDT();
     }
     client.emit('new-user', crdts[room].getStruct());
     client.join(room);
-  })
-  client.on('local-insert', data => { 
-    const roomName = Array.from(client.rooms)[1];
-    crdts[roomName].saveInsert(data); 
-    client.to(roomName).emit('remote-insert', data); 
   });
-  client.on('local-delete', data => { 
+  client.on('title-update', (newTitle) => {
+    const roomName = Array.from(client.rooms)[1];
+    client.to(roomName).emit('new-title', newTitle);
+  });
+  client.on('local-insert', (data) => {
+    const roomName = Array.from(client.rooms)[1];
+    crdts[roomName].saveInsert(data);
+    client.to(roomName).emit('remote-insert', data);
+  });
+  client.on('local-delete', (data) => {
     const roomName = Array.from(client.rooms)[1];
     crdts[roomName].saveDeleteRange(data);
     client.to(roomName).emit('remote-delete', data);
   });
   client.on('disconnect', () => {
-    console.log("Socket disconnected");
+    console.log('Socket disconnected');
   });
 });
 
-app.set('port', 8100)
+app.set('port', 8100);
 
 httpServer.listen(app.get('port'), function () {
   console.log('Running on : ', 8100);

--- a/frontend/src/atoms/titleAtom.ts
+++ b/frontend/src/atoms/titleAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const titleState = atom({
+  key: 'title',
+  default: 'Untitled'
+});
+
+export { titleState };

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -2,19 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { SiteLogo } from '../siteLogo';
 import useTitle from '../../hooks/useTitle';
+import { copyURLPath } from '../../utils/utils';
 
 const EditorHeader = () => {
   const { title, onTitleChange } = useTitle('Untitled');
-  const copyURLPath = () => {
-    try {
-      const url = window.location.href;
-      navigator.clipboard
-        .writeText(url)
-        .then(() => alert('주소가 복사되었습니다.\n문서를 다른 사람에게 공유해보세요!'));
-    } catch (e) {
-      alert('주소 복사에 실패했어요 ㅠㅠ');
-    }
-  };
 
   return (
     <>

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -5,13 +5,13 @@ import useTitle from '../../hooks/useTitle';
 import { copyURLPath } from '../../utils/utils';
 
 const EditorHeader = () => {
-  const { title, onTitleChange } = useTitle('Untitled');
+  const { title, onTitleChange, onTitleUpdate } = useTitle();
 
   return (
     <>
       <HeaderContainer>
         <SiteLogo />
-        <DocumentTitle type="text" value={title} onChange={onTitleChange} />
+        <DocumentTitle type="text" value={title} onChange={onTitleChange} onBlur={onTitleUpdate} />
         <RightButtonWrapper>
           <ShareButton type="button" onClick={copyURLPath}>
             Share

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import { SiteLogo } from '../siteLogo';
+
+const EditorHeader = () => {
+  return (
+    <>
+      <HeaderContainer>
+        <SiteLogo />
+        <DocumentTitle type="text" />
+        <RightButtonWrapper>
+          <ShareButton type="button">Share</ShareButton>
+          <Peer>3</Peer>
+        </RightButtonWrapper>
+      </HeaderContainer>
+    </>
+  );
+};
+
+const HeaderContainer = styled.header`
+  width: 100vw;
+  height: 5vh;
+  padding: 0 1rem;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const DocumentTitle = styled.input`
+  width: 16rem;
+  font-weight: 200;
+  font-size: 24px;
+  line-height: 29px;
+  text-align: center;
+
+  border: none;
+
+  :focus {
+    border: 1px solid #222222;
+  }
+
+  :hover {
+    border: 1px solid #3a7dff;
+  }
+`;
+
+const RightButtonWrapper = styled.div`
+  width: 9rem;
+  height: 1.5rem;
+
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const ShareButton = styled.button`
+  padding: 0.5rem 1.5rem;
+  background: #3a7dff;
+  border-radius: 10px;
+
+  font-weight: 700;
+  font-size: 0.9rem;
+  line-height: 1rem;
+  color: #ffffff;
+`;
+
+const Peer = styled.div`
+  width: 2.75rem;
+`;
+
+export { EditorHeader };

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -5,6 +5,16 @@ import useTitle from '../../hooks/useTitle';
 
 const EditorHeader = () => {
   const { title, onTitleChange } = useTitle('Untitled');
+  const copyURLPath = () => {
+    try {
+      const url = window.location.href;
+      navigator.clipboard
+        .writeText(url)
+        .then(() => alert('주소가 복사되었습니다.\n문서를 다른 사람에게 공유해보세요!'));
+    } catch (e) {
+      alert('주소 복사에 실패했어요 ㅠㅠ');
+    }
+  };
 
   return (
     <>
@@ -12,7 +22,9 @@ const EditorHeader = () => {
         <SiteLogo />
         <DocumentTitle type="text" value={title} onChange={onTitleChange} />
         <RightButtonWrapper>
-          <ShareButton type="button">Share</ShareButton>
+          <ShareButton type="button" onClick={copyURLPath}>
+            Share
+          </ShareButton>
           <Peer>3</Peer>
         </RightButtonWrapper>
       </HeaderContainer>

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { SiteLogo } from '../siteLogo';
 
 const EditorHeader = () => {
+  const [title, setTitle] = useState<string>('Untitled');
+
+  const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
   return (
     <>
       <HeaderContainer>
         <SiteLogo />
-        <DocumentTitle type="text" />
+        <DocumentTitle type="text" value={title} onChange={onTitleChange} />
         <RightButtonWrapper>
           <ShareButton type="button">Share</ShareButton>
           <Peer>3</Peer>

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { SiteLogo } from '../siteLogo';
+import useTitle from '../../hooks/useTitle';
 
 const EditorHeader = () => {
-  const [title, setTitle] = useState<string>('Untitled');
-
-  const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
+  const { title, onTitleChange } = useTitle('Untitled');
 
   return (
     <>

--- a/frontend/src/components/editorHeader/index.ts
+++ b/frontend/src/components/editorHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './EditorHeader';

--- a/frontend/src/components/siteLogo/SiteLogo.tsx
+++ b/frontend/src/components/siteLogo/SiteLogo.tsx
@@ -25,7 +25,7 @@ const LogoImg = styled.img`
 const LogoTitle = styled.span`
   font-size: 1.5rem;
   font-weight: 700;
-  padding: 1rem;
+  padding: 0.5rem;
 `;
 
 export { SiteLogo };

--- a/frontend/src/hooks/useTitle.ts
+++ b/frontend/src/hooks/useTitle.ts
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+
+const useTitle = (initTitle: string) => {
+  const [title, setTitle] = useState<string>(initTitle);
+
+  const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  return {
+    title,
+    onTitleChange
+  };
+};
+
+export default useTitle;

--- a/frontend/src/hooks/useTitle.ts
+++ b/frontend/src/hooks/useTitle.ts
@@ -1,15 +1,31 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
+import socket from '../core/sockets/sockets';
+import { useRecoilState } from 'recoil';
+import { titleState } from '../atoms/titleAtom';
 
-const useTitle = (initTitle: string) => {
-  const [title, setTitle] = useState<string>(initTitle);
-
+const useTitle = () => {
+  const [title, setTitle] = useRecoilState(titleState);
   const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
 
+  const onTitleUpdate = () => {
+    socket.emit('title-update', title);
+  };
+
+  useEffect(() => {
+    socket.on('new-title', (newTitle) => {
+      setTitle(newTitle);
+    });
+    return () => {
+      socket.removeAllListeners();
+    };
+  }, []);
+
   return {
     title,
-    onTitleChange
+    onTitleChange,
+    onTitleUpdate
   };
 };
 

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Editor from '../components/Editor';
+import { EditorHeader } from '../components/editorHeader';
 
 const DocumentPage = () => {
   return (
     <>
+      <EditorHeader />
       <Editor />
     </>
   );

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,0 +1,12 @@
+const copyURLPath = () => {
+  try {
+    const url = window.location.href;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => alert('주소가 복사되었습니다.\n문서를 다른 사람에게 공유해보세요!'));
+  } catch (e) {
+    alert('주소 복사에 실패했어요 ㅠㅠ');
+  }
+};
+
+export { copyURLPath };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 관련 이슈
- #72 

### 변경 사항
![image](https://user-images.githubusercontent.com/78531103/206125614-eff267c0-15ef-4785-9255-1a3aa8c187a8.png)

* 에디터 페이지 헤더를 제작하였습니다.
* Title을 Recoil State로 관리하도록 /atoms/titleAtom.ts에 titleState를 추가하였습니다.
* 제목은 추후 저장 요청시에도 반영해야 할 데이터라 header 컴포넌트의 지역 상태로 관리하기 무리가 있다고 판단하였습니다.
* 제목 수정은 Blur시 다른 클라이언트에게 바꾼 제목을 덮어 씌우는 식으로 구현하였습니다.
* 제목 업데이트와 관련하여 클라이언트와 소켓 서버에 이벤트 리스너를 장착하였습니다.
* 관련 기능은 커스텀 훅으로 분리하였습니다. (useTitle.ts)

![image](https://user-images.githubusercontent.com/78531103/206126275-4e078348-e2d5-46f0-b963-b9ec40e19df2.png)
* 현재 URL을 클립보드에 복사하는 기능을 추가하였습니다.
* 관련 메서드를 utils.ts 파일에 함수로 분리하였습니다.

### 동작 확인
![image](https://user-images.githubusercontent.com/78531103/206125972-e1c6a919-7128-4ea1-879c-2ed03c391ac6.png)
![image](https://user-images.githubusercontent.com/78531103/206126005-768f58a4-9060-40c6-a62f-b01e52952ba7.png)
