### PR TITLE
새로운 문서를 생성하는 버튼 

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -3,10 +3,22 @@ import styled from 'styled-components';
 import { Header } from '../components/header';
 import { SideBar } from '../components/sideBar';
 import { DocListContainer } from '../components/docListContainer';
-import { IconButton } from '../components/iconButton';
 import { ReactComponent as PencilIcon } from '../../src/assets/pencil.svg';
+import { useNavigate } from 'react-router-dom';
 
 const MainPage = () => {
+  const navigate = useNavigate();
+
+  const handleCreateNewDocument = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try {
+      const response = await fetch('/document/new');
+      const newDocumentId = await response.json();
+      navigate(`../${newDocumentId}`);
+    } catch (err) {
+      alert('새로운 문서 생성에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
 
   return (
     <>
@@ -14,10 +26,8 @@ const MainPage = () => {
       <Container>
         <SideBar />
         <ContentWrapper>
-          <NewDocBtn>
-            <IconButton fill={'#FFFFFF'} width={'1.5'} height={'1.5'} >
-              <PencilIcon />
-            </IconButton>
+          <NewDocBtn onClick={handleCreateNewDocument}>
+            <PencilIcon />
             <BtnText>새로운 문서 작성</BtnText>
           </NewDocBtn>
           <ContentHeaderGroup>
@@ -62,6 +72,9 @@ const NewDocBtn = styled.button`
   background-color: #3A7DFF;
   padding: 1.25rem 2rem 1.25rem 1.5rem;
   margin-bottom: 2rem;
+  svg {
+    fill: #fff;
+  }
   &:hover {
     span {
       color: #3A7DFF;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -3,14 +3,23 @@ import styled from 'styled-components';
 import { Header } from '../components/header';
 import { SideBar } from '../components/sideBar';
 import { DocListContainer } from '../components/docListContainer';
+import { IconButton } from '../components/iconButton';
+import { ReactComponent as PencilIcon } from '../../src/assets/pencil.svg';
 
 const MainPage = () => {
+
   return (
     <>
       <Header />
       <Container>
         <SideBar />
         <ContentWrapper>
+          <NewDocBtn>
+            <IconButton fill={'#FFFFFF'} width={'1.5'} height={'1.5'} >
+              <PencilIcon />
+            </IconButton>
+            <BtnText>새로운 문서 작성</BtnText>
+          </NewDocBtn>
           <ContentHeaderGroup>
             <Title>최근 문서 목록</Title>
             <div>드롭다운</div>
@@ -29,7 +38,7 @@ const Container = styled.main`
 
 const ContentWrapper = styled.section`
   flex: 1;
-  margin: 2rem 3.5rem;
+  margin: 3rem 3.5rem;
   overflow-y: scroll;
 `;
 
@@ -43,6 +52,33 @@ const ContentHeaderGroup = styled.div`
 const Title = styled.h1`
   font-weight: 800;
   font-size: 2rem;
+`;
+
+const NewDocBtn = styled.button`
+  display: flex;
+  align-items: center;
+  border-radius: 10px;
+  border: 1px solid #3A7DFF;
+  background-color: #3A7DFF;
+  padding: 1.25rem 2rem 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+  &:hover {
+    span {
+      color: #3A7DFF;
+    }
+    svg {
+      fill: #3A7DFF;
+    }
+    background-color: #FFFFFF;
+  }
+`;
+  
+const BtnText = styled.span`
+  font-weight: 500;
+  font-size: 20px;
+  color: #FFFFFF;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  margin-left: 0.5rem;
 `;
 
 export default MainPage;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #22 

### 변경 사항
새로운 문서를 생성하는 버튼을 MainPage 내부에 생성했습니다. 
클릭하면 서버로부터 uuid 를 받아와서 해당 주소로 이동하는 이벤트를 등록했습니다. 
추후에 API 주소를 바꿔야합니다!
연필 아이콘에 IconButton 을 적용하려고 했는데 
button 태그 안에 button 태그가 있으면 안된다고 오류를 뱉어서 그냥 일반 ReactComponent 로 사용했습니다. 

### 동작 확인

![화면-기록-2022-12-07-21 45 00](https://user-images.githubusercontent.com/31645195/206182920-4e690cc9-a0ae-4d0e-9412-179900a12721.gif)