### PR TITLE
에디터 페이지 레이아웃 조정

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -16,7 +16,7 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "indent": ["error", 2],
+    //"indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "single"],
     "semi": ["error", "always"],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "@types/socket.io-client": "^3.0.0",
-        "easymde": "^2.18.0",
+        "easymde": "^2.16.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
@@ -25,7 +25,7 @@
         "recoil": "^0.7.6",
         "socket.io-client": "^4.5.4",
         "styled-components": "^5.3.6",
-        "styled-reset": "^4.4.2",
+        "styled-normalize": "^8.0.7",
         "typescript": "^4.8.4",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
@@ -3933,9 +3933,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/marked": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.7.tgz",
-      "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.3.tgz",
+      "integrity": "sha512-ZgAr847Wl68W+B0sWH7F4fDPxTzerLnRuUXjUpp1n4NjGSs8hgPAjAp7NQIXblG34MXTrf5wWkAK8PVJ2LIlVg=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -6814,15 +6814,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "node_modules/easymde": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.18.0.tgz",
-      "integrity": "sha512-IxVVUxNWIoXLeqtBU4BLc+eS/ScYhT1Dcb6yF5Wchoj1iXAV+TIIDWx+NCaZhY7RcSHqDPKllbYq7nwGKILnoA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.16.0.tgz",
+      "integrity": "sha512-RNeb+JGCBfbhlyuwGfBqImt3lWeb8sy/3AH7O7IRk0N6YMwVXIKAam5Ph2H4cbjHl1mkAJ/ssxqbytLQvZsISA==",
       "dependencies": {
         "@types/codemirror": "^5.60.4",
-        "@types/marked": "^4.0.7",
+        "@types/marked": "^3.0.1",
         "codemirror": "^5.63.1",
         "codemirror-spell-checker": "1.1.2",
-        "marked": "^4.1.0"
+        "marked": "^3.0.4"
       }
     },
     "node_modules/ee-first": {
@@ -12269,11 +12269,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-      "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
       "bin": {
-        "marked": "bin/marked.js"
+        "marked": "bin/marked"
       },
       "engines": {
         "node": ">= 12"
@@ -16422,19 +16422,12 @@
         "react-is": ">= 16.8.0"
       }
     },
-    "node_modules/styled-reset": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.2.tgz",
-      "integrity": "sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==",
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/zacanger"
-      },
+    "node_modules/styled-normalize": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
+      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ==",
       "peerDependencies": {
-        "styled-components": ">=4.0.0 || >=5.0.0"
+        "styled-components": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/stylehacks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
     "@types/socket.io-client": "^3.0.0",
-    "easymde": "^2.18.0",
+    "easymde": "^2.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
@@ -20,7 +20,7 @@
     "recoil": "^0.7.6",
     "socket.io-client": "^4.5.4",
     "styled-components": "^5.3.6",
-    "styled-reset": "^4.4.2",
+    "styled-normalize": "^8.0.7",
     "typescript": "^4.8.4",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"

--- a/frontend/src/GlobalStyles.ts
+++ b/frontend/src/GlobalStyles.ts
@@ -1,8 +1,8 @@
 import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
+import normalize from 'styled-normalize';
 
 const GlobalStyles = createGlobalStyle` 
-  ${reset}
+  ${normalize}
     body {
         font-family: 'Inter', sans-serif;
     } 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,14 @@
+.editor-preview-side {
+  position: fixed;
+  bottom: 0;
+  width: 50%;
+  max-height: calc(100vh - 120px);
+  top: 50px;
+  right: 0;
+  z-index: 9;
+  overflow: auto;
+  display: none;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  word-wrap: break-word;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 if (process.env.NODE_ENV === 'development') {
-  import('./mocks/worker')
-    .then(({ worker }) => worker.start());
+  import('./mocks/worker').then(({ worker }) => worker.start());
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 관련 이슈
- #73 

### 변경 사항
에디터 부분을 화면 전체를 차지하도록 레이아웃을 배치했습니다.
SimpleMDE 에디터의 스타일링을 적용하기 위해 index.css 파일을 생성하였습니다.
또한 옵션에서 viewport, rem 단위를 인식하지 못해 px 단위로 max, minHeight를 지정하였습니다. 
overflow 시에 max-height를 유지하도록 조정하였습니다. 

### 동작 확인
![image](https://user-images.githubusercontent.com/78531103/206185807-9e80941a-30cf-45ef-8257-f3dc97950513.png)
![image](https://user-images.githubusercontent.com/78531103/206186046-fe23ed4f-d5ee-4681-8ad4-4000f8e9e6e2.png)
