### PR TITLE
Header 중앙에 페이지 제목 표시 및 Outlet 적용 

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,6 +1,7 @@
 import React, { lazy } from 'react';
 import GlobalStyles from './GlobalStyles';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import MainLayout from './pages/MainLayout';
 
 const LandingPage = lazy(() => import('./pages/LandingPage'));
 const MainPage = lazy(() => import('./pages/MainPage'));
@@ -12,14 +13,14 @@ const Router = () => {
       <GlobalStyles />
       <Routes>
         <Route path="/" element={<LandingPage />} />
-        <Route path="/document">
+        <Route path="/document" element={<MainLayout />}>
           <Route path="main" element={<MainPage />} />
           <Route path="private" element="" />
           <Route path="shared" element="" />
           <Route path="bookmark" element="" />
           <Route path="trash" element="" />
-          <Route path=":document_id" element={<DocumentPage />} />
         </Route>
+        <Route path="/document/:document_id" element={<DocumentPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -1,9 +1,28 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
 import { SiteLogo } from '../siteLogo';
 import { UserProfile } from '../userProfile';
 
+interface pageTitles {
+  [key: string] : string, 
+}
+
 const Header = () => {
+  const [currentPath, setCurrentPath] = useState('');
+  const location = useLocation();
+
+  const pageTitleByPath: pageTitles = {
+    'main': '최근 문서 목록',
+    'private' : '내 문서함',
+    'shared' : '공유 문서함',
+  };
+
+  useEffect(() => {
+    const lastPath = location.pathname.split('/').slice(-1);
+    setCurrentPath(pageTitleByPath[lastPath[0]]);
+  }, [location]);
+  
   const profileProps = {
     profileImgURL: 'https://picsum.photos/200',
     userName: 'iyu88'
@@ -12,7 +31,7 @@ const Header = () => {
   return (
     <HeaderWrapper>
       <SiteLogo />
-      <PageTitle>최근 문서 목록</PageTitle>
+      <PageTitle>{currentPath}</PageTitle>
       <UserProfile {...profileProps}/>
     </HeaderWrapper>
   );

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -1,28 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
 import { SiteLogo } from '../siteLogo';
 import { UserProfile } from '../userProfile';
-
-interface pageTitles {
-  [key: string] : string, 
-}
+import usePageName from '../../hooks/usePageName';
 
 const Header = () => {
-  const [currentPath, setCurrentPath] = useState('');
-  const location = useLocation();
+  const { pageName } = usePageName();
 
-  const pageTitleByPath: pageTitles = {
-    'main': '최근 문서 목록',
-    'private' : '내 문서함',
-    'shared' : '공유 문서함',
-  };
-
-  useEffect(() => {
-    const lastPath = location.pathname.split('/').slice(-1);
-    setCurrentPath(pageTitleByPath[lastPath[0]]);
-  }, [location]);
-  
   const profileProps = {
     profileImgURL: 'https://picsum.photos/200',
     userName: 'iyu88'
@@ -31,7 +15,7 @@ const Header = () => {
   return (
     <HeaderWrapper>
       <SiteLogo />
-      <PageTitle>{currentPath}</PageTitle>
+      <PageName>{pageName}</PageName>
       <UserProfile {...profileProps}/>
     </HeaderWrapper>
   );
@@ -45,7 +29,7 @@ const HeaderWrapper = styled.div`
   border-bottom: 1px solid #BBBBBB;
 `;
 
-const PageTitle = styled.span`
+const PageName = styled.span`
   font-size: 1rem;
   font-weight: 500;
 `;

--- a/frontend/src/hooks/usePageName.ts
+++ b/frontend/src/hooks/usePageName.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect }  from 'react';
+import { useState, useEffect }  from 'react';
 import { useLocation } from 'react-router-dom';
 
 interface pageNames {
@@ -18,9 +18,9 @@ const usePageName = () => {
   };
 
   useEffect(() => {
-    const lastPath = location.pathname.split('/').slice(-1);
-    setPageName(pageNamesByPath[lastPath[0]]);
-  }, [location]);
+    const [ lastPath ] = location.pathname.split('/').slice(-1);
+    setPageName(pageNamesByPath[lastPath]);
+  });
 
   return { pageName };
 };

--- a/frontend/src/hooks/usePageName.ts
+++ b/frontend/src/hooks/usePageName.ts
@@ -1,0 +1,28 @@
+import React, { useState, useEffect }  from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface pageNames {
+  [key: string] : string, 
+}
+
+const usePageName = () => {
+  const [pageName, setPageName] = useState('');
+  const location = useLocation();
+
+  const pageNamesByPath: pageNames = {
+    'main': '최근 문서 목록',
+    'private' : '내 문서함',
+    'shared' : '공유 문서함',
+    'bookmark' : '북마크',
+    'trash': '휴지통',
+  };
+
+  useEffect(() => {
+    const lastPath = location.pathname.split('/').slice(-1);
+    setPageName(pageNamesByPath[lastPath[0]]);
+  }, [location]);
+
+  return { pageName };
+};
+
+export default usePageName;

--- a/frontend/src/pages/MainLayout.tsx
+++ b/frontend/src/pages/MainLayout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Header } from '../components/header';
+import { SideBar } from '../components/sideBar';
+import { Outlet } from 'react-router-dom';
+
+const MainLayout = () => {
+  return (
+    <>
+      <Header />
+      <Container>
+        <SideBar />
+        <Outlet />
+      </Container>
+    </>
+  );
+};
+
+const Container = styled.main`
+  display: flex;
+`;
+
+export default MainLayout;
+

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Header } from '../components/header';
-import { SideBar } from '../components/sideBar';
 import { DocListContainer } from '../components/docListContainer';
 import { ReactComponent as PencilIcon } from '../../src/assets/pencil.svg';
 import { useNavigate } from 'react-router-dom';
@@ -21,30 +19,20 @@ const MainPage = () => {
   };
 
   return (
-    <>
-      <Header />
-      <Container>
-        <SideBar />
-        <ContentWrapper>
-          <NewDocBtn onClick={handleCreateNewDocument}>
-            <PencilIcon />
-            <BtnText>새로운 문서 작성</BtnText>
-          </NewDocBtn>
-          <ContentHeaderGroup>
-            <Title>최근 문서 목록</Title>
-            <div>드롭다운</div>
-            {/* TODO: <Dropdown /> */}
-          </ContentHeaderGroup>
-          <DocListContainer />
-        </ContentWrapper>
-      </Container>
-    </>
+    <ContentWrapper>
+      <NewDocBtn onClick={handleCreateNewDocument}>
+        <PencilIcon />
+        <BtnText>새로운 문서 작성</BtnText>
+      </NewDocBtn>
+      <ContentHeaderGroup>
+        <Title>최근 문서 목록</Title>
+        <div>드롭다운</div>
+        {/* TODO: <Dropdown /> */}
+      </ContentHeaderGroup>
+      <DocListContainer />
+    </ContentWrapper>
   );
 };
-
-const Container = styled.main`
-  display: flex;
-`;
 
 const ContentWrapper = styled.section`
   flex: 1;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 import { DocListContainer } from '../components/docListContainer';
 import { ReactComponent as PencilIcon } from '../../src/assets/pencil.svg';
 import { useNavigate } from 'react-router-dom';
+import usePageName from '../hooks/usePageName';
 
 const MainPage = () => {
+  const { pageName } = usePageName(); 
   const navigate = useNavigate();
 
   const handleCreateNewDocument = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -25,7 +27,7 @@ const MainPage = () => {
         <BtnText>새로운 문서 작성</BtnText>
       </NewDocBtn>
       <ContentHeaderGroup>
-        <Title>최근 문서 목록</Title>
+        <PageName>{pageName}</PageName>
         <div>드롭다운</div>
         {/* TODO: <Dropdown /> */}
       </ContentHeaderGroup>
@@ -47,7 +49,7 @@ const ContentHeaderGroup = styled.div`
   margin-bottom: 2rem;
 `;
 
-const Title = styled.h1`
+const PageName = styled.h1`
   font-weight: 800;
   font-size: 2rem;
 `;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #64 

### 변경 사항
사용자가 위치한 페이지의 제목을 Header 중앙에 표시합니다. 
또한 usePageName 이라는 커스텀 훅으로 분리했습니다. 
큰 변화는 react-router-dom 의 Outlet 을 적용했습니다. 
문서 목록 페이지에서 Header / SideBar 등을 공유하고 목록이 렌더링되는 부분만 별도의 컴포넌트로 관리하도록 했습니다. 

### 동작 확인


#### Header 의 제목과 문서 목록 위의 제목이 동시에 변경됩니다. 

![화면-기록-2022-12-07-23 38 47](https://user-images.githubusercontent.com/31645195/206208375-c96bbbb6-3731-4689-904a-ea8fdf378466.gif)


### 🚨 고민
현재 Outlet 을 적용한 컴포넌트의 이름은 `<MainLayout>` 인데 
이 안에 document/main 경로에 해당하는 `<MainPage>` 가 위치하는 것이 부자연스러운 것 같습니다. 
이미 최근 문서 목록은 main 이라는 이름으로 통일된 것 같아서 
`<MainLayout>` 의 이름을 바꾸는 것이 나을 것 같은데
1) 이에 대한 의견과
2) 동의하신다면 이름 추천 부탁드립니다 🙇‍♂️
