### PR TITLE
Dropdown 컴포넌트 및 DropdownOption 컴포넌트 구현 

### DIFF
--- a/frontend/src/assets/angle-down.svg
+++ b/frontend/src/assets/angle-down.svg
@@ -1,0 +1,23 @@
+<svg width="25" height="26" viewBox="0 0 25 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_dd_233_887)">
+<path d="M11.6699 17.2021L5.0293 10.5615C4.57031 10.1025 4.57031 9.36035 5.0293 8.90625L6.13281 7.80273C6.5918 7.34375 7.33398 7.34375 7.78809 7.80273L12.4951 12.5098L17.2021 7.80273C17.6611 7.34375 18.4033 7.34375 18.8574 7.80273L19.9609 8.90625C20.4199 9.36523 20.4199 10.1074 19.9609 10.5615L13.3203 17.2021C12.8711 17.6611 12.1289 17.6611 11.6699 17.2021Z" fill="current"/>
+</g>
+<defs>
+<filter id="filter0_dd_233_887" x="-4" y="0" width="33" height="33" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_233_887"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_233_887" result="effect2_dropShadow_233_887"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_233_887" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -19,7 +19,10 @@ const Dropdown = () => {
 
   const handleSelectOption = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setSelectedOption(e.currentTarget.innerText);
+    const clickedValue = e.currentTarget.value;
+    if (optionList.includes(clickedValue)) {
+      setSelectedOption(clickedValue);
+    }
     setIsOptionOpened(() => !isOptionOpened);
   };
 

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { ReactComponent as AngleDownIcon } from '../../assets/angle-down.svg';
+
+interface optionOpenedProps {
+  isOptionOpened : boolean;
+}
+
+const Dropdown = () => {
+  const [isOptionOpened, setIsOptionOpened] = useState<boolean>(false);
+  const [selectedOption, setSelectedOption] = useState<string>('최근 방문순');
+  const optionList = ['최근 방문순', '제목순', '생성일순'];
+
+  const handleOpenOption = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsOptionOpened(() => !isOptionOpened);
+  };
+
+  const handleSelectOption = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setSelectedOption(e.currentTarget.innerText);
+    setIsOptionOpened(() => !isOptionOpened);
+  };
+
+  return (
+    <DropdownWrapper isOptionOpened={isOptionOpened}>
+      <DropdownOption onClick={handleOpenOption}>
+        <OptionTitle>{selectedOption}</OptionTitle>
+        <AngleDownIcon fill={'#fff'}/>
+      </DropdownOption>
+      <DropdownOptionList isOptionOpened={isOptionOpened}>
+        {
+          optionList.map((option, index) => {
+            return (
+              <li key={index}>
+                <DropdownOption onClick={handleSelectOption}>
+                  <OptionTitle>{option}</OptionTitle>
+                </DropdownOption>
+              </li>
+            );
+          })
+        }
+      </DropdownOptionList>
+    </DropdownWrapper>
+  );
+};
+
+const DropdownWrapper = styled('div')<optionOpenedProps>`
+  width: 140px;
+  background-color: #222;
+  border-radius: ${(props) => props.isOptionOpened ? '10px 10px 0 0' : '10px'};
+`;
+
+const DropdownOption = styled.button`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  color: #fff;
+  border-bottom: 1px solid #D9D9D9;
+`;
+
+const OptionTitle = styled.span`
+  padding-right: 0.5rem;
+`;
+
+const DropdownOptionList = styled('ul')<optionOpenedProps>`
+  width: 140px;
+  list-style-type: none;
+  position: absolute;
+  border-radius: 0 0 10px 10px;
+  padding: 0 0.25rem;
+  margin: 0;
+  background-color: #222;
+  display: ${(props) => props.isOptionOpened ? 'block' : 'none'};
+`;
+
+export { Dropdown };

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import DropdownOption from '../dropdownOption/DropdownOption';
 import { ReactComponent as AngleDownIcon } from '../../assets/angle-down.svg';
 
 interface optionOpenedProps {
@@ -24,8 +25,7 @@ const Dropdown = () => {
 
   return (
     <DropdownWrapper isOptionOpened={isOptionOpened}>
-      <DropdownOption onClick={handleOpenOption}>
-        <OptionTitle>{selectedOption}</OptionTitle>
+      <DropdownOption optionTitle={selectedOption} clickHandler={handleOpenOption} >
         <AngleDownIcon fill={'#fff'}/>
       </DropdownOption>
       <DropdownOptionList isOptionOpened={isOptionOpened}>
@@ -33,9 +33,7 @@ const Dropdown = () => {
           optionList.map((option, index) => {
             return (
               <li key={index}>
-                <DropdownOption onClick={handleSelectOption}>
-                  <OptionTitle>{option}</OptionTitle>
-                </DropdownOption>
+                <DropdownOption optionTitle={option} clickHandler={handleSelectOption} />
               </li>
             );
           })
@@ -47,29 +45,15 @@ const Dropdown = () => {
 
 const DropdownWrapper = styled('div')<optionOpenedProps>`
   width: 140px;
+  border-radius: 10px;
   background-color: #222;
-  border-radius: ${(props) => props.isOptionOpened ? '10px 10px 0 0' : '10px'};
-`;
-
-const DropdownOption = styled.button`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  color: #fff;
-  border-bottom: 1px solid #D9D9D9;
-`;
-
-const OptionTitle = styled.span`
-  padding-right: 0.5rem;
 `;
 
 const DropdownOptionList = styled('ul')<optionOpenedProps>`
   width: 140px;
   list-style-type: none;
   position: absolute;
-  border-radius: 0 0 10px 10px;
+  border-radius: 10px;
   padding: 0 0.25rem;
   margin: 0;
   background-color: #222;

--- a/frontend/src/components/dropdown/index.ts
+++ b/frontend/src/components/dropdown/index.ts
@@ -1,0 +1,1 @@
+export * from './Dropdown';

--- a/frontend/src/components/dropdownOption/DropdownOption.tsx
+++ b/frontend/src/components/dropdownOption/DropdownOption.tsx
@@ -9,8 +9,8 @@ interface DropdownOptionProps {
 
 const DropdownOption = ({optionTitle, clickHandler, children: dropdownIcon}: DropdownOptionProps) => {
   return (
-    <DropdownOptionWrapper onClick={clickHandler}>
-      <OptionTitle>{optionTitle}</OptionTitle>
+    <DropdownOptionWrapper onClick={clickHandler} value={optionTitle}>
+      {optionTitle}
       {dropdownIcon}
     </DropdownOptionWrapper>
   )
@@ -25,10 +25,6 @@ const DropdownOptionWrapper = styled.button`
   padding: 1rem;
   color: #fff;
   border-bottom: 1px solid #fff;
-`;
-
-const OptionTitle = styled.span`
-  padding-right: 0.5rem;
 `;
 
 export default DropdownOption;

--- a/frontend/src/components/dropdownOption/DropdownOption.tsx
+++ b/frontend/src/components/dropdownOption/DropdownOption.tsx
@@ -1,0 +1,34 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface DropdownOptionProps {
+  optionTitle: string
+  clickHandler?: React.MouseEventHandler
+  children?: ReactNode,
+}
+
+const DropdownOption = ({optionTitle, clickHandler, children: dropdownIcon}: DropdownOptionProps) => {
+  return (
+    <DropdownOptionWrapper onClick={clickHandler}>
+      <OptionTitle>{optionTitle}</OptionTitle>
+      {dropdownIcon}
+    </DropdownOptionWrapper>
+  )
+  ;
+};
+
+const DropdownOptionWrapper = styled.button`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  color: #fff;
+  border-bottom: 1px solid #fff;
+`;
+
+const OptionTitle = styled.span`
+  padding-right: 0.5rem;
+`;
+
+export default DropdownOption;

--- a/frontend/src/components/dropdownOption/index.ts
+++ b/frontend/src/components/dropdownOption/index.ts
@@ -1,0 +1,1 @@
+export * from './DropdownOption';


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #87 

### 변경 사항
Dropdown 컴포넌트와 DropdownOption 컴포넌트를 만들었습니다. 
상태 관리에 대해서는 변경점이 많을 것 같아서 dev 브랜치에 머지하고 나서 추가적인 브랜치를 생성해서 처리할 계획입니다.
Dropdown 으로 변경된 상태를 DocListContainer 에 전달하여 fetching 한 데이터를 정렬하는 순서로 진행할까 하는데,
이 과정에서 DocListContainer 가 사라질 수도 있다고 생각합니다만,
정확한 것은 서버 상태 관리 라이브러리를 도입한 뒤에 정해질 것 같습니다. 
아마 위에서 명시한 작업들은 다음주 리팩토링 주간에 진행하지 않을까 합니다.

### 동작 확인

#### Dropdown 작동

![화면-기록-2022-12-10-23 50 58](https://user-images.githubusercontent.com/31645195/206866167-a11b59ba-282d-472f-82e1-5b903fc585da.gif)

|스타일 변경 전 |스타일 변경 후|
|-------------|-------------|
|![스크린샷 2022-12-11 00 02 36](https://user-images.githubusercontent.com/31645195/206866214-329a813a-bf1e-422c-a41e-68e0883dac3b.png)|![스크린샷 2022-12-11 00 27 00](https://user-images.githubusercontent.com/31645195/206866217-99624465-6ada-4fcd-8cdf-9e706dc17605.png)|


#### 🚧  알림
스타일을 우측에서 좌측으로 변경했는데요.
이유인즉슨, 
본디 정렬을 위한 스타일 컴포넌트인 DropdownOptionList 을 우측처럼 만들었다가 
에디터 페이지에서 접속 인원을 표시하는 작은 컴포넌트를 피그마에서 발견하여
DropdownOptionList 를 좌측처럼 디자인하면 재사용할 수 있지 않을까 해서 바꿨습니다. 
일단 별도의 React 컴포넌트로 분리하지는 않았고 
실제로 인원 표시하는 컴포넌트를 구현할 때 사용해보다가 
겹치는 부분이 많을 때 분리하면 좋을 것 같습니다. 

