### PR TITLE
DocListItem 버튼에 API 호출 함수 및 Modal 실행 함수 전달

### DIFF
--- a/frontend/src/atoms/modalAtom.ts
+++ b/frontend/src/atoms/modalAtom.ts
@@ -2,7 +2,12 @@ import { atom } from 'recoil';
 
 const modalState = atom({
   key: 'modal',
-  default: false,
+  default: {
+    type: 'INIT',
+    clickHandler: () => { 
+      return; 
+    }
+  },
 });
 
 export { modalState };

--- a/frontend/src/components/docList/DocList.tsx
+++ b/frontend/src/components/docList/DocList.tsx
@@ -1,17 +1,30 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { DocListItem } from '../docListItem';
 import { fetchDataFromPath } from '../../utils/fetchBeforeRender';
 import { useQuery } from 'react-query';
+import useToast from '../../hooks/useToast';
 
 interface DocListProps {
+  documentType: string,
   sortOption: string
 }
 
+interface RequestPathMap {
+  [key: string]: string
+}
+
 // TODO: props 로 API 세부 주소 받기 
-const DocList = ({ sortOption }:DocListProps) => {
-  const { data: docList } = useQuery('docList', () => fetchDataFromPath('/user-document/recent'), {
-    refetchOnWindowFocus: false,
+const DocList = ({ documentType, sortOption }:DocListProps) => {
+  const { alertToast } = useToast();
+
+  const reqPathByDocumentType: RequestPathMap = {
+    recent: '/user-document/recent',
+    bookmark: '/bookmark',
+    shared: '/user-document/shared',
+  };
+
+  const { data: docList } = useQuery(`${documentType}`, () => fetchDataFromPath(`${reqPathByDocumentType[documentType]}`), {
     suspense: true,
     onError: e => {
       console.log(e);
@@ -19,26 +32,60 @@ const DocList = ({ sortOption }:DocListProps) => {
   });
 
   const sortDocListByOption = (prev: DocListItem, next: DocListItem) => {
-    return prev[sortOption] > next[sortOption] ? 1 : -1; 
+    // return prev[sortOption] > next[sortOption] ? 1 : -1; 
   };
+
+  const handleDeleteDocument = useCallback(async (id: string) => {
+    try {
+      // TODO: URL 수정 + response statusCode 조건문 추가
+      await fetch(`/document/${id}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include'
+      });
+      alertToast('INFO', '문서를 성공적으로 삭제했습니다.');     
+    } catch (err) {
+      alertToast('WARNING', '문서 삭제에 실패했습니다. 다시 시도해주세요.');     
+    }
+  }, []);
+
+  const handleBookmarkDocument = useCallback(async (id: string) => {
+    try {
+      // TODO: URL 수정 + response statusCode 조건문 추가
+      await fetch(`/bookmark/${id}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'include'
+      });
+      alertToast('INFO', '북마크에 추가했습니다.');     
+    } catch (err) {
+      alertToast('WARNING', '북마크에 추가하지 못했습니다. 다시 시도해주세요.');     
+    }
+  }, []);
   
   return (
-      <DocListWrapper>
-        {
-          docList?.sort(sortDocListByOption).map((doc: DocListItem) => {
-            return (
-              <DocListItem
-                key={doc.id}
-                id={doc.id}
-                title={doc.title}
-                lastVisited={doc.lastVisited}
-                role={doc.role}
-                createdAt={doc.createdAt}
-              />
+    <DocListWrapper>
+      {
+        docList?.sort(sortDocListByOption).map((doc: DocListItem) => {
+          return (
+            <DocListItem
+            key={doc.id}
+            id={doc.id}
+            title={doc.title}
+            lastVisited={doc.lastVisited}
+            role={doc.role}
+            createdAt={doc.createdAt}
+            handleBookmark={handleBookmarkDocument}
+            handleDelete={handleDeleteDocument}
+            />
             );
-          })
-        }
-      </DocListWrapper>
+        })
+      }
+    </DocListWrapper> 
   );
 };
 

--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -5,50 +5,20 @@ import { COLOR_ACTIVE, COLOR_CAUTION } from '../../constants/styled';
 import { ReactComponent as TrashIcon } from '../../assets/trash.svg';
 import { ReactComponent as BookmarkIcon } from '../../assets/bookmark.svg';
 import { IconButton } from '../iconButton';
-import useToast from '../../hooks/useToast';
+import { useRecoilState } from 'recoil';
+import { modalState } from '../../atoms/modalAtom';
 
-const DocListItem = ({ id, title, lastVisited, role, createdAt }: DocListItem) => {
-  const { alertToast } = useToast();
+interface DocListItemWithClickHandler extends DocListItem {
+  handleBookmark: (id: string) => void,
+  handleDelete: (id: string) => void,
+}
+
+const DocListItem = ({ id, title, lastVisited, role, createdAt, handleBookmark, handleDelete}: DocListItemWithClickHandler) => {
+  const [modalData, setModalData] = useRecoilState(modalState);
   const docListItemStyles = {
     fill: '#A5A5A5',
     width: '0.75',
     height: '0.75'
-  };
-
-  const handleDeleteDocument = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    try {
-      // TODO: URL 수정 + response statusCode 조건문 추가
-      const response = await fetch(`/document/${id}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include'
-      });
-      throw Error('강제 에러');
-      alertToast('INFO', '문서를 성공적으로 삭제했습니다.');     
-    } catch (err) {
-      alertToast('WARNING', '문서 삭제에 실패했습니다. 다시 시도해주세요.');     
-    }
-  };
-
-  const handleBookmarkDocument = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    try {
-      // TODO: URL 수정 + response statusCode 조건문 추가
-      const response = await fetch(`/document/${id}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include'
-      });
-      throw Error('강제 에러');
-      alertToast('INFO', '북마크에 추가했습니다.');     
-    } catch (err) {
-      alertToast('WARNING', '북마크에 추가하지 못했습니다. 다시 시도해주세요.');     
-    }
   };
 
   return (
@@ -60,13 +30,29 @@ const DocListItem = ({ id, title, lastVisited, role, createdAt }: DocListItem) =
           <IconGroup>
             <li>
               {role === 'owner' && (
-                <IconButton {...docListItemStyles} hover={COLOR_CAUTION} clickHandler={handleDeleteDocument}>
+                <IconButton {...docListItemStyles} hover={COLOR_CAUTION} clickHandler={(e) => {
+                  e.preventDefault();
+                  setModalData({
+                    type: 'DELETE',
+                    clickHandler: () => {
+                      handleDelete(id);
+                    },
+                  });
+                }}>
                   <TrashIcon />
                 </IconButton>
               )}
             </li>
             <li>
-              <IconButton {...docListItemStyles} hover={COLOR_ACTIVE} clickHandler={handleBookmarkDocument}>
+              <IconButton {...docListItemStyles} hover={COLOR_ACTIVE} clickHandler={(e) => {
+                  e.preventDefault();
+                  setModalData({
+                    type: 'BOOKMARK',
+                    clickHandler: () => {
+                      handleBookmark(id);
+                    },
+                  });
+              }}>
                 <BookmarkIcon />
               </IconButton>
             </li>

--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -1,45 +1,34 @@
 import React, { useRef } from 'react';
 import styled from 'styled-components';
+import { ModalDoubleChecker } from '../modalDoubleChecker';
 import { useRecoilState } from 'recoil';
 import { modalState } from '../../atoms/modalAtom';
 
 interface DimmedProps {
-  isVisible: boolean;
-}
-
-interface AnswerBtnProps {
-  backgroundColor: string;
+  modalType: string;
 }
 
 const Modal = () => {
-  const [isVisible, setIsVisible] = useRecoilState(modalState);
+  const [modalData, setModalData] = useRecoilState(modalState);
   const dimmedRef = useRef<HTMLDivElement | null>(null);
 
   const handleCloseModal = (e: React.MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
     e.preventDefault();
-    if (e.target === dimmedRef.current) {
-      setIsVisible(false);
-      console.log(isVisible);
+    console.log(e.target);
+    if (e.target) {
+      setModalData({
+          type: 'INIT',
+          clickHandler: () => { 
+            return Promise<void>;
+          },
+        });
+      console.log(modalData);
     }
   };
 
   return (
-      <Dimmed ref={dimmedRef} isVisible={isVisible} onClick={handleCloseModal}>
-        <ModalContent>
-          <Question>
-            <QuestionTitle>
-            정말로 삭제하시겠습니까?
-            </QuestionTitle>
-            <QuestionDescribtion>
-              한 번 삭제한 문서는 복구할 수 없습니다.
-              그래도 진행하시겠습니까?
-            </QuestionDescribtion>
-          </Question>
-          <Answers>
-            <AnswerBtn backgroundColor={'#A5A5A5'}>취소</AnswerBtn>
-            <AnswerBtn backgroundColor={'#FF5757'}>확인</AnswerBtn>
-          </Answers>
-        </ModalContent>
+      <Dimmed ref={dimmedRef} modalType={modalData.type} onClick={handleCloseModal}>
+        {modalData.clickHandler && <ModalDoubleChecker modalType={modalData.type} modalCancelHandler={handleCloseModal} modalActionHandler={modalData.clickHandler} />}
       </Dimmed>
   );
 };
@@ -52,49 +41,7 @@ const Dimmed = styled('div')<DimmedProps>`
   left: 0;
   background-color: rgba(30, 30, 30, 0.9);
   z-index: 1000;
-  display: ${(props) => props.isVisible ? 'block': 'none'};
-`;
-
-const ModalContent = styled.div`
-  width: 550px;
-  min-height: 450px;
-  border-radius: 10px;
-  background-color: #DFDFDF;
-  padding: 6.5rem 2rem;
-  margin: 0 auto;
-  margin-top: 4rem;
-`;
-
-const Question = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 0 4rem 3rem 4rem;
-`;
-
-const QuestionTitle = styled.h2`
-  font-size: 2rem;
-  font-weight: 700;
-`;
-
-const QuestionDescribtion = styled.p`
-  max-width: 330px;
-  word-break: keep-all;
-  margin-top: 0;
-`;
-
-const Answers = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const AnswerBtn = styled('button')<AnswerBtnProps>`
-  font-size: 20px;
-  border-radius: 10px;
-  padding: 1rem 6rem;
-  color: white;
-  background-color: ${(props) => props.backgroundColor};
+  display: ${(props) => props.modalType === 'INIT' ? 'none': 'block'};
 `;
 
 export { Modal };

--- a/frontend/src/components/modalDoubleChecker/ModalDoubleChecker.tsx
+++ b/frontend/src/components/modalDoubleChecker/ModalDoubleChecker.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface DoubleCheckerProps {
+  modalType: string,
+  modalCancelHandler: React.MouseEventHandler
+  modalActionHandler: () => void
+}
+
+interface CheckerType {
+  questionTitle: string,
+  questionDescription: string
+}
+
+interface CheckerByType {
+  [key: string] : CheckerType;
+}
+
+interface AnswerBtnProps {
+  backgroundColor: string;
+}
+
+const ModalDoubleChecker = ({modalType, modalCancelHandler,  modalActionHandler}: DoubleCheckerProps) => {
+  const checkerByType: CheckerByType = {
+    'DELETE' : {
+      questionTitle: '정말로 삭제하시겠습니까?',
+      questionDescription: '한 번 삭제한 문서는 복원할 수 없습니다. 그래도 진행하시겠습니까?',
+    }, 
+    'BOOKMARK': {
+      questionTitle: '북마크에 등록합니까?',
+      questionDescription: '북마크에 등록합니까?',
+    }
+  };
+
+  if (modalType === 'INIT') {
+    return <></>;
+  } else {
+    return (
+      <ModalContent>
+        <Question>
+          <QuestionTitle>
+          {checkerByType[modalType].questionTitle}
+          </QuestionTitle>
+          <QuestionDescription>
+            {checkerByType[modalType].questionDescription}
+          </QuestionDescription>
+        </Question>
+        <Answers>
+          <AnswerBtn backgroundColor={'#A5A5A5'} onClick={modalCancelHandler}>취소</AnswerBtn>
+          <AnswerBtn backgroundColor={'#FF5757'} onClick={(e) => {
+            modalActionHandler();
+            modalCancelHandler(e);
+          }}>확인</AnswerBtn>
+        </Answers>
+      </ModalContent>
+    );
+  }
+};
+
+const ModalContent = styled.div`
+  width: 550px;
+  min-height: 450px;
+  border-radius: 10px;
+  background-color: #DFDFDF;
+  padding: 6.5rem 2rem;
+  margin: 0 auto;
+  margin-top: 4rem;
+`;
+
+const Question = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 4rem 3rem 4rem;
+`;
+
+const QuestionTitle = styled.h2`
+  font-size: 2rem;
+  font-weight: 700;
+`;
+
+const QuestionDescription = styled.p`
+  max-width: 330px;
+  word-break: keep-all;
+  margin-top: 0;
+`;
+
+const Answers = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const AnswerBtn = styled('button')<AnswerBtnProps>`
+  font-size: 20px;
+  border-radius: 10px;
+  padding: 1rem 6rem;
+  color: white;
+  background-color: ${(props) => props.backgroundColor};
+`;
+
+export { ModalDoubleChecker };

--- a/frontend/src/components/modalDoubleChecker/ModalDoubleChecker.tsx
+++ b/frontend/src/components/modalDoubleChecker/ModalDoubleChecker.tsx
@@ -27,8 +27,8 @@ const ModalDoubleChecker = ({modalType, modalCancelHandler,  modalActionHandler}
       questionDescription: '한 번 삭제한 문서는 복원할 수 없습니다. 그래도 진행하시겠습니까?',
     }, 
     'BOOKMARK': {
-      questionTitle: '북마크에 등록합니까?',
-      questionDescription: '북마크에 등록합니까?',
+      questionTitle: '북마크에 등록하시겠습니까?',
+      questionDescription: '등록한 문서는 북마크 페이지에서 확인할 수 있습니다.',
     }
   };
 

--- a/frontend/src/components/modalDoubleChecker/index.ts
+++ b/frontend/src/components/modalDoubleChecker/index.ts
@@ -1,0 +1,1 @@
+export * from './ModalDoubleChecker';

--- a/frontend/src/mocks/dummy/docList.ts
+++ b/frontend/src/mocks/dummy/docList.ts
@@ -25,9 +25,6 @@ const createDocumentList = (counts: number): DocListItem[] => {
         lastVisited: new Date(getRandomDate()).getTime().toString(),
         role: roleEnumMock[Math.floor(Math.random() * 3 + 1)],
         createdAt: new Date(getRandomDate()).getTime().toString(),
-        bookmark: false,
-        shared: false,
-        isDeleted: false,
       };
     });
 };

--- a/frontend/src/mocks/dummy/docList.ts
+++ b/frontend/src/mocks/dummy/docList.ts
@@ -24,7 +24,10 @@ const createDocumentList = (counts: number): DocListItem[] => {
         title: Math.random().toFixed(4).slice(2).toString(),
         lastVisited: new Date(getRandomDate()).getTime().toString(),
         role: roleEnumMock[Math.floor(Math.random() * 3 + 1)],
-        createdAt: new Date(getRandomDate()).getTime().toString()
+        createdAt: new Date(getRandomDate()).getTime().toString(),
+        bookmark: false,
+        shared: false,
+        isDeleted: false,
       };
     });
 };

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -22,29 +22,28 @@ const dummyDocList = generateDummy('docList', 30) as DocListItem[];
 
 export const handler = [
   rest.get('/user-document/recent', (req, res, ctx) => {
-    const recentDocList = dummyDocList.filter(doc => doc.isDeleted === false);
-    return res(ctx.status(200), ctx.json(recentDocList));
+    return res(ctx.status(200), ctx.json(dummyDocList));
   }),
-  rest.get('/user-document/shared', (req, res, ctx) => {
-    // TODO: 공유된 문서만 반환하도록 수정 
-    const sharedDocList = dummyDocList.filter(doc => doc.shared === true && doc.isDeleted === false);
-    return res(ctx.status(200), ctx.json(sharedDocList));
-  }),
-  rest.get('/bookmark', (req, res, ctx) => {
-    // TODO: 북마크된 문서만 반환하도록 수정
-    const bookmarkDocList = dummyDocList.filter(doc => doc.bookmark === true && doc.isDeleted === false); 
-    return res(ctx.status(200), ctx.json(bookmarkDocList));
-  }),
-  rest.post('/bookmark/:id', (req, res, ctx) => {
-    dummyDocList.some(doc => {
-      if (doc.id === req.params.id) {
-        doc.bookmark = true;
-        return true;
-      }
-      return false;
-    });
-    return res(ctx.status(200));
-  }),
+  // rest.get('/user-document/shared', (req, res, ctx) => {
+  //   // TODO: 공유된 문서만 반환하도록 수정 
+  //   const sharedDocList = dummyDocList.filter(doc => doc.shared === true && doc.isDeleted === false);
+  //   return res(ctx.status(200), ctx.json(sharedDocList));
+  // }),
+  // rest.get('/bookmark', (req, res, ctx) => {
+  //   // TODO: 북마크된 문서만 반환하도록 수정
+  //   const bookmarkDocList = dummyDocList.filter(doc => doc.bookmark === true && doc.isDeleted === false); 
+  //   return res(ctx.status(200), ctx.json(bookmarkDocList));
+  // }),
+  // rest.post('/bookmark/:id', (req, res, ctx) => {
+  //   dummyDocList.some(doc => {
+  //     if (doc.id === req.params.id) {
+  //       doc.bookmark = true;
+  //       return true;
+  //     }
+  //     return false;
+  //   });
+  //   return res(ctx.status(200));
+  // }),
   rest.get('/document/:id', (req, res, ctx) => {
     const [ targetDocument ] = dummyDocList.filter(doc => doc.id === req.params.id);
     return res(ctx.status(200), ctx.json(
@@ -52,16 +51,16 @@ export const handler = [
       content: charMap }
     ));
   }),
-  rest.delete('/document/:id', (req, res, ctx) => {
-    dummyDocList.some(doc => {
-      if (doc.id === req.params.id) {
-        doc.isDeleted = true;
-        return true;
-      }
-      return false;
-    });
-    return res(ctx.status(200));
-  }),
+  // rest.delete('/document/:id', (req, res, ctx) => {
+  //   dummyDocList.some(doc => {
+  //     if (doc.id === req.params.id) {
+  //       doc.isDeleted = true;
+  //       return true;
+  //     }
+  //     return false;
+  //   });
+  //   return res(ctx.status(200));
+  // }),
   rest.post('/document', (req, res, ctx) => {
     const newDocument = generateDummy('newDocument') as DocListItem;
     dummyDocList.push(newDocument);

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -22,7 +22,28 @@ const dummyDocList = generateDummy('docList', 30) as DocListItem[];
 
 export const handler = [
   rest.get('/user-document/recent', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(dummyDocList));
+    const recentDocList = dummyDocList.filter(doc => doc.isDeleted === false);
+    return res(ctx.status(200), ctx.json(recentDocList));
+  }),
+  rest.get('/user-document/shared', (req, res, ctx) => {
+    // TODO: 공유된 문서만 반환하도록 수정 
+    const sharedDocList = dummyDocList.filter(doc => doc.shared === true && doc.isDeleted === false);
+    return res(ctx.status(200), ctx.json(sharedDocList));
+  }),
+  rest.get('/bookmark', (req, res, ctx) => {
+    // TODO: 북마크된 문서만 반환하도록 수정
+    const bookmarkDocList = dummyDocList.filter(doc => doc.bookmark === true && doc.isDeleted === false); 
+    return res(ctx.status(200), ctx.json(bookmarkDocList));
+  }),
+  rest.post('/bookmark/:id', (req, res, ctx) => {
+    dummyDocList.some(doc => {
+      if (doc.id === req.params.id) {
+        doc.bookmark = true;
+        return true;
+      }
+      return false;
+    });
+    return res(ctx.status(200));
   }),
   rest.get('/document/:id', (req, res, ctx) => {
     const [ targetDocument ] = dummyDocList.filter(doc => doc.id === req.params.id);
@@ -30,6 +51,16 @@ export const handler = [
       {...targetDocument,
       content: charMap }
     ));
+  }),
+  rest.delete('/document/:id', (req, res, ctx) => {
+    dummyDocList.some(doc => {
+      if (doc.id === req.params.id) {
+        doc.isDeleted = true;
+        return true;
+      }
+      return false;
+    });
+    return res(ctx.status(200));
   }),
   rest.post('/document', (req, res, ctx) => {
     const newDocument = generateDummy('newDocument') as DocListItem;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -39,7 +39,7 @@ const MainPage = () => {
         <PageName>{pageName}</PageName>
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner/>}>
-        <DocList sortOption={'lastVisited'}/>
+        <DocList documentType={'recent'} sortOption={'lastVisited'}/>
       </Suspense>
     </ContentWrapper>
   );

--- a/frontend/src/pages/PrivatePage.tsx
+++ b/frontend/src/pages/PrivatePage.tsx
@@ -16,7 +16,7 @@ const PrivatePage = () => {
         <Dropdown selectedOption={selectedOption} selectedOptionSetter={setSelectedOption}/>
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner/>}>
-        <DocList sortOption={selectedOption} />
+        <DocList documentType={'recent'} sortOption={selectedOption} />
       </Suspense>
     </ContentWrapper>
   );

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -16,7 +16,7 @@ const SharedPage = () => {
         <Dropdown selectedOption={selectedOption} selectedOptionSetter={setSelectedOption}/>
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner/>}>
-        <DocList sortOption={selectedOption} />
+        <DocList documentType={'recent'} sortOption={selectedOption} />
       </Suspense>
     </ContentWrapper>
   );

--- a/frontend/src/types/document.d.ts
+++ b/frontend/src/types/document.d.ts
@@ -1,3 +1,7 @@
 declare type DocListItem = {
-  [key: string]: string
+  id: string
+  title: string
+  lastVisited: string
+  role: string
+  createdAt: string
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #86 

### 변경 사항
기존에 Modal 컴포넌트 내부에 있던 ModalContent 를 컴포넌트로 분리했습니다. 
Modal 의 전역 상태에 따라 내부에 표현될 컴포넌트가 변합니다. 
DocList 에서 useCallback 으로 선언한 API 요청이 DocListItem -> IconButton -> ModalDoubleChecker 로 전달됩니다. 

### 동작 확인

문서에 있는 아이콘을 누르면 Modal 이 등장하고 확인 버튼을 누르면 API 요청을 보냅니다. 
