### PR TITLE
에디터에 접속 중인 인원을 표시하는 OnlinePeople 컴포넌트 구현 

### DIFF
--- a/frontend/src/assets/online.svg
+++ b/frontend/src/assets/online.svg
@@ -1,3 +1,3 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="current" xmlns="http://www.w3.org/2000/svg">
-<path d="M20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10Z" fill="current"/>
+<path d="M19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10Z" fill="current" stroke="white" stroke-width="2"/>
 </svg>

--- a/frontend/src/assets/online.svg
+++ b/frontend/src/assets/online.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10Z" fill="current"/>
+</svg>

--- a/frontend/src/components/editorHeader/EditorHeader.tsx
+++ b/frontend/src/components/editorHeader/EditorHeader.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { SiteLogo } from '../siteLogo';
 import useTitle from '../../hooks/useTitle';
 import useToast from '../../hooks/useToast';
+import { OnlinePeople } from '../../components/onlinePeople';
 
 interface EditorHeaderProps {
   titleProp: string;
@@ -37,7 +38,7 @@ const EditorHeader = ({ titleProp }: EditorHeaderProps) => {
           <ShareButton type="button" onClick={handleCopyURL}>
             Share
           </ShareButton>
-          <Peer>3</Peer>
+          <OnlinePeople />
         </RightButtonWrapper>
       </HeaderContainer>
     </>
@@ -86,8 +87,5 @@ const ShareButton = styled.button`
   color: #ffffff;
 `;
 
-const Peer = styled.div`
-  width: 2.75rem;
-`;
 
 export { EditorHeader };

--- a/frontend/src/components/onlinePeople/OnlinePeople.tsx
+++ b/frontend/src/components/onlinePeople/OnlinePeople.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import DropdownOption from '../dropdownOption/DropdownOption';
+import { ReactComponent as TogetherIcon } from '../../assets/together.svg';
+import { ReactComponent as OnlineIcon } from '../../assets/online.svg';
+
+interface OnlinePeopleState {
+  id: string,
+  name: string,
+  color: string,
+}
+
+interface OptionOpenedProps {
+  isOptionOpened : boolean;
+}
+
+const OnlinePeople = () => {
+  const [isOptionOpened, setIsOptionOpened] = useState<boolean>(false);
+  const [onlinePeopleInfo, setOnlinePeopleInfo] = useState<OnlinePeopleState[]>([
+    {
+      id: 'test1',
+      name: 'J001',
+      color: '#770287'
+    },
+    {
+      id: 'test2',
+      name: 'J128',
+      color: '#778589'
+    }, 
+    {
+      id: 'test3',
+      name: 'J164',
+      color: '#F39B2B'
+    },
+  ]);
+
+  const handleOpenOption = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsOptionOpened(() => !isOptionOpened);
+  };
+
+  return (
+    <OnlinePeopleWrapper>
+      <OnlinePeopleCount onClick={handleOpenOption}>
+        <TogetherIcon fill={'#000'}/>
+        <BtnNumber>{onlinePeopleInfo.length}</BtnNumber>
+      </OnlinePeopleCount>
+      <OnlinePeopleList isOptionOpened={isOptionOpened}>
+      {
+        onlinePeopleInfo.map(person => {
+          return (
+            <li key={person.id}>
+              <DropdownOption optionTitle={person.name} optionValue={person.id}>
+                <OnlineIcon fill={person.color}/>
+              </DropdownOption>
+            </li>
+          );
+        })
+      }
+      </OnlinePeopleList>
+    </OnlinePeopleWrapper>
+  );
+};
+
+const OnlinePeopleWrapper = styled.div`
+  width: 140px;
+  z-index: 500;
+  cursor: pointer;
+`;
+
+const OnlinePeopleCount = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
+const BtnNumber = styled.span`
+  font-weight: 500;
+  font-size: 20px;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  margin-left: 0.5rem;
+`;
+
+const OnlinePeopleList = styled('ul')<OptionOpenedProps>`
+  width: 140px;
+  list-style-type: none;
+  position: absolute;
+  top: 3rem;
+  right: 0;
+  border-radius: 10px;
+  padding: 0 0.25rem;
+  margin: 0;
+  background-color: #222;
+  display: ${(props) => props.isOptionOpened ? 'block' : 'none'};
+`;
+
+export { OnlinePeople };

--- a/frontend/src/components/onlinePeople/index.ts
+++ b/frontend/src/components/onlinePeople/index.ts
@@ -1,0 +1,1 @@
+export * from './OnlinePeople';


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- #100 

### 변경 사항
Dropdown 을 만들 때 사용했던 컴포넌트를 참고하여 OnlinePeople 컴포넌트를 만들었습니다. 
컴포넌트를 누르면 현재 접속 중인 사용자들의 이름 / 커서 색상이 표시됩니다. 

### 동작 확인

#### 클릭하면 접속자 목록이 나옵니다. 

![화면-기록-2022-12-14-14 26 17](https://user-images.githubusercontent.com/31645195/207514491-341409e3-98c4-49cb-b8c0-adc094dc8a3c.gif)

#### 🧐 클릭을 위한 State 가 필요할까요?

클릭을 했을 때 state 가 변경되어 목록이 있는 Wrapper 태그의 display 속성이 block 으로 변경되면서 화면에 나오는데요,
그냥 hover 로 처리한다면
state 를 관리하지 않고 css 내부 동작으로만 처리할 수도 있겠다 싶긴합니다. 
근데 또 나~~중에 권한을 설정하는 기능을 넣는다고 치면 
클릭 이벤트와 state 가 있어도 나쁘지 않을 것 같다는 생각도 드네요.
의견 있으시면 알려주세요!
