### PR TITLE
[Refactor] Dropdown 리팩토링

### DIFF
--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -1,78 +1,38 @@
-import React, { useState, SetStateAction } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import DropdownOption from '../dropdownOption/DropdownOption';
+import { DropdownTrigger } from './DropdownTrigger';
+import { DropdownMenu } from './DropdownMenu';
+import { DropdownItem } from './DropdownItem';
 import { ReactComponent as AngleDownIcon } from '../../assets/angle-down.svg';
 
 interface DropdownProps {
-  selectedOption : string
-  selectedOptionSetter: React.Dispatch<SetStateAction<string>>
+  value: string,
+  onClick: React.Dispatch<React.SetStateAction<string>>,
+  options: {[key:string] : string},
 }
 
-interface OptionOpenedProps {
-  isOptionOpened : boolean;
-}
-
-interface OptionMap {
-  [key: string] : string
-}
-
-const Dropdown = ({selectedOption, selectedOptionSetter}: DropdownProps) => {
-  const [isOptionOpened, setIsOptionOpened] = useState<boolean>(false);
-  const optionList: OptionMap = {
-    'lastVisited': '최근 방문순',
-    'title': '제목순',
-    'createdAt': '생성일순'
-  };
-
-  const handleOpenOption = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setIsOptionOpened(() => !isOptionOpened);
-  };
-
-  const handleSelectOption = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    const clickedValue = e.currentTarget.value;
-    if (Object.keys(optionList).includes(clickedValue)) {
-      selectedOptionSetter(clickedValue); 
-    }
-    setIsOptionOpened(() => !isOptionOpened);
-  };
+const Dropdown = ({value, onClick, options}: DropdownProps) => {
+  const [isOpened, setIsOpened] = useState<boolean>(false); 
 
   return (
-    <DropdownWrapper isOptionOpened={isOptionOpened}>
-      <DropdownOption optionTitle={optionList[selectedOption]} clickHandler={handleOpenOption} >
-        <AngleDownIcon fill={'#fff'}/>
-      </DropdownOption>
-      <DropdownOptionList isOptionOpened={isOptionOpened}>
+    <DropdownWrapper>
+      <DropdownTrigger value={options[value]} onClick={setIsOpened} icon={<AngleDownIcon fill={'#fff'}/>} />
+      <DropdownMenu display={isOpened}>
         {
-          Object.keys(optionList).map((option, index) => {
-            return (
-              <li key={index}>
-                <DropdownOption optionTitle={optionList[option]} optionValue={option} clickHandler={handleSelectOption} />
-              </li>
-            );
-          })
+          Object.keys(options).map((option, index) => (
+              <DropdownItem key={index} text={options[option]} value={option} onClick={onClick}/>
+            )
+          )
         }
-      </DropdownOptionList>
+      </DropdownMenu>
     </DropdownWrapper>
   );
 };
 
-const DropdownWrapper = styled('div')<OptionOpenedProps>`
+const DropdownWrapper = styled.div`
   width: 140px;
   border-radius: 10px;
   background-color: #222;
-`;
-
-const DropdownOptionList = styled('ul')<OptionOpenedProps>`
-  width: 140px;
-  list-style-type: none;
-  position: absolute;
-  border-radius: 10px;
-  padding: 0 0.25rem;
-  margin: 0;
-  background-color: #222;
-  display: ${(props) => props.isOptionOpened ? 'block' : 'none'};
 `;
 
 export { Dropdown };

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -17,7 +17,7 @@ const Dropdown = ({value, onClick, options}: DropdownProps) => {
   return (
     <DropdownWrapper>
       <DropdownTrigger value={options[value]} onClick={setIsOpened} icon={<AngleDownIcon fill={'#fff'}/>} />
-      <DropdownMenu display={isOpened}>
+      <DropdownMenu isOpened={isOpened}>
         {
           Object.keys(options).map((option, index) => (
               <DropdownItem key={index} text={options[option]} value={option} onClick={onClick}/>

--- a/frontend/src/components/dropdown/DropdownItem.tsx
+++ b/frontend/src/components/dropdown/DropdownItem.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface DropdownItemProps {
+  text: string,
+  value: string,
+  onClick: React.Dispatch<React.SetStateAction<string>>,
+}
+
+const DropdownItem = ({text, value, onClick}: DropdownItemProps) => {
+  
+  const handleItemSelection = (e: React.MouseEvent<HTMLLIElement>) => {
+    const target = e.target as HTMLLIElement;
+    onClick(String(target.dataset['value']));
+  };
+
+  return (
+    <Dropdown_Item onClick={handleItemSelection} data-value={value}>
+      {text}
+    </Dropdown_Item>
+  );
+};
+
+const Dropdown_Item = styled.li`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0.75rem;
+  color: #fff;
+  border-bottom: 1px solid #fff;
+  cursor: pointer;
+`;
+
+export { DropdownItem };

--- a/frontend/src/components/dropdown/DropdownMenu.tsx
+++ b/frontend/src/components/dropdown/DropdownMenu.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface DropdownMenuProps {
+  display: boolean,
+  children: ReactNode,
+}
+
+interface MenuProps {
+  display: boolean,
+}
+
+const DropdownMenu = ({display, children}: DropdownMenuProps) => {
+  return (
+    <Dropdown_Menu display={display}>
+      {children}
+    </Dropdown_Menu>
+  );
+};
+
+const Dropdown_Menu = styled('ul')<MenuProps>`
+  width: 140px;
+  list-style-type: none;
+  position: absolute;
+  border-radius: 10px;
+  padding: 0 0.25rem;
+  margin: 0;
+  background-color: #222;
+  display: ${(props) => props.display ? 'block' : 'none'};
+`;
+
+export { DropdownMenu };

--- a/frontend/src/components/dropdown/DropdownMenu.tsx
+++ b/frontend/src/components/dropdown/DropdownMenu.tsx
@@ -2,17 +2,17 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
 interface DropdownMenuProps {
-  display: boolean,
+  isOpened: boolean,
   children: ReactNode,
 }
 
 interface MenuProps {
-  display: boolean,
+  isOpened: boolean,
 }
 
-const DropdownMenu = ({display, children}: DropdownMenuProps) => {
+const DropdownMenu = ({isOpened, children}: DropdownMenuProps) => {
   return (
-    <Dropdown_Menu display={display}>
+    <Dropdown_Menu isOpened={isOpened}>
       {children}
     </Dropdown_Menu>
   );
@@ -26,7 +26,7 @@ const Dropdown_Menu = styled('ul')<MenuProps>`
   padding: 0 0.25rem;
   margin: 0;
   background-color: #222;
-  display: ${(props) => props.display ? 'block' : 'none'};
+  display: ${(props) => props.isOpened ? 'block' : 'none'};
 `;
 
 export { DropdownMenu };

--- a/frontend/src/components/dropdown/DropdownTrigger.tsx
+++ b/frontend/src/components/dropdown/DropdownTrigger.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface DropdownTriggerProps {
+  value: string,
+  onClick: React.Dispatch<React.SetStateAction<boolean>>,
+  icon?: ReactNode;
+}
+
+const DropdownTrigger = ({value, onClick, icon}: DropdownTriggerProps) => {
+  
+  const handleOptionDisplay = (e:React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    onClick((isOpened) => !isOpened);
+  };
+
+  return (
+    <Dropdown_Trigger onClick={handleOptionDisplay}>
+      {value && 
+        <SelectedOption>
+          {value}
+        </SelectedOption>
+      }
+      {icon}
+    </Dropdown_Trigger>
+  );
+};
+
+const Dropdown_Trigger = styled.button`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0.75rem;
+  color: #fff;
+  border-bottom: 1px solid #fff;
+`;
+
+const SelectedOption = styled.span`
+  white-space: pre-line;
+`;
+
+export { DropdownTrigger };

--- a/frontend/src/hooks/useSortOption.ts
+++ b/frontend/src/hooks/useSortOption.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+interface OptionMap {
+  [key: string] : string
+}
+
+const useSortOption = (initialOption: string) => {
+  const [option, setOption] = useState<string>(initialOption);
+  const optionList: OptionMap = {
+    'lastVisited': '최근 방문순',
+    'title': '제목순',
+    'createdAt': '생성일순'
+  };
+
+  return { option, optionList, setOption };
+};
+
+export default useSortOption;

--- a/frontend/src/pages/BookmarkPage.tsx
+++ b/frontend/src/pages/BookmarkPage.tsx
@@ -1,22 +1,27 @@
-import React, { useState, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import styled from 'styled-components';
 import usePageName from '../hooks/usePageName';
+import useSortOption from '../hooks/useSortOption';
 import { DocList } from '../components/docList';
 import { Spinner } from '../components/spinner';
 import { Dropdown } from '../components/dropdown';
 
 const BookmarkPage = () => {
   const { pageName } = usePageName();
-  const [selectedOption, setSelectedOption] = useState<string>('lastVisited');
-
+  const {option, optionList, setOption} = useSortOption('lastVisited');
+  
   return (
     <ContentWrapper>
       <ContentHeaderGroup>
         <PageName>{pageName}</PageName>
-        <Dropdown selectedOption={selectedOption} selectedOptionSetter={setSelectedOption} />
+        <Dropdown
+          value={option}
+          onClick={setOption}
+          options={optionList}
+        />
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner />}>
-        <DocList documentType={'bookmark'} sortOption={selectedOption} />
+        <DocList documentType={'bookmark'} sortOption={option} />
       </Suspense>
     </ContentWrapper>
   );

--- a/frontend/src/pages/PrivatePage.tsx
+++ b/frontend/src/pages/PrivatePage.tsx
@@ -1,22 +1,27 @@
-import React, { useState, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import styled from 'styled-components';
 import usePageName from '../hooks/usePageName';
+import useSortOption from '../hooks/useSortOption';
 import { DocList } from '../components/docList';
 import { Spinner } from '../components/spinner';
 import { Dropdown } from '../components/dropdown';
 
 const PrivatePage = () => {
   const { pageName } = usePageName();
-  const [selectedOption, setSelectedOption] = useState<string>('lastVisited');
+  const {option, optionList, setOption} = useSortOption('lastVisited');
 
   return (
     <ContentWrapper>
       <ContentHeaderGroup>
         <PageName>{pageName}</PageName>
-        <Dropdown selectedOption={selectedOption} selectedOptionSetter={setSelectedOption} />
+        <Dropdown
+          value={option}
+          onClick={setOption}
+          options={optionList}
+        />
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner />}>
-        <DocList documentType={'private'} sortOption={selectedOption} />
+        <DocList documentType={'private'} sortOption={option} />
       </Suspense>
     </ContentWrapper>
   );

--- a/frontend/src/pages/SharedPage.tsx
+++ b/frontend/src/pages/SharedPage.tsx
@@ -1,22 +1,27 @@
-import React, { useState, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import styled from 'styled-components';
 import usePageName from '../hooks/usePageName';
+import useSortOption from '../hooks/useSortOption';
 import { DocList } from '../components/docList';
 import { Spinner } from '../components/spinner';
 import { Dropdown } from '../components/dropdown';
 
 const SharedPage = () => {
   const { pageName } = usePageName();
-  const [selectedOption, setSelectedOption] = useState<string>('lastVisited');
+  const {option, optionList, setOption} = useSortOption('lastVisited');
 
   return (
     <ContentWrapper>
       <ContentHeaderGroup>
         <PageName>{pageName}</PageName>
-        <Dropdown selectedOption={selectedOption} selectedOptionSetter={setSelectedOption} />
+        <Dropdown
+          value={option}
+          onClick={setOption}
+          options={optionList}
+        />
       </ContentHeaderGroup>
       <Suspense fallback={<Spinner />}>
-        <DocList documentType={'shared'} sortOption={selectedOption} />
+        <DocList documentType={'shared'} sortOption={option} />
       </Suspense>
     </ContentWrapper>
   );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 리팩토링

### 변경 사항
- 문서 목록의 정렬 순서를 결정하는 데에 사용하는 Dropdown UI 컴포넌트를 리팩토링했습니다. 
- Dropdown 내부에서 Style 컴포넌트로 존재했던 부분을 React 컴포넌트로 분리했습니다. 
- Dropdown 을 구성하는 UI 의 각 역할에 따라 분리했습니다. 
  1) Dropdown :  내부에서 메뉴를 Toggle 하는 isOpened 상태만 관리합니다. 구체적인 메뉴는 외부에서 주입받습니다.
  2) DropdownTrigger : 사용자가 선택한 옵션을 표시합니다. Dropdown 메뉴를 Toggle 합니다. 
  3) DropdownMenu : Dropdown 메뉴를 Wrapping 하는 컴포넌트입니다. 기존에 Style 컴포넌트로 존재했던 부분을 분리한 컴포넌트입니다.
  4) DropdownItem : 사용자가 옵션을 선택하면 Dropdown 컴포넌트가 props 로 받는 상태를 업데이트합니다. 
- 사용자가 선택한 옵션과 옵션 목록을 가지고 있는 useSortOption 커스텀 훅을 생성했습니다. 
  - 기존에 Dropdown 컴포넌트 안에서 강결합되어 있던 데이터를 분리했습니다. 
- Dropdown 컴포넌트 + useSortOption 훅 적용 
  - 북마크 페이지, 내 문서함, 공유 문서함에서 수정한 내용을 적용했습니다. 

### 동작 확인
기존 코드와 동일하게 작동합니다.