### PR TITLE
[Fix] DocListItem 컴포넌트 내부 아이콘 이벤트 핸들러 수정 

### DIFF
--- a/frontend/src/components/docListItem/DocListItem.tsx
+++ b/frontend/src/components/docListItem/DocListItem.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
 import { Link } from 'react-router-dom';
-// import { COLOR_ACTIVE, COLOR_CAUTION } from '../../constants/styled';
 import { ReactComponent as TrashIcon } from '../../assets/trash.svg';
 import { ReactComponent as BookmarkIcon } from '../../assets/bookmark.svg';
 import { IconButton } from '../iconButton';
 import { Modal } from '../modal';
 import { ModalForm } from '../modalForm';
 import useModal from '../../hooks/useModal';
-
 
 interface DocListItemProps extends DocListItem {
   bookmarkMutate: MutateProp,
@@ -40,8 +38,8 @@ const DocListItem = (props: DocListItemProps) => {
 
   const handleDocumentAction = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    const target = e.target as HTMLButtonElement;
-    const modalType = target.dataset['value'];
+    const target = e.currentTarget.closest('button');
+    const modalType = target?.dataset['value'];
     if (!modalType) {
       return;
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정

### 관련 이슈
- #118 

### 변경 사항
- DocListItem 이 발생시키는 이벤트 핸들러 내부에서 e.currentTarget 과 closest 를 사용하여 가장 가까운 button 태그에 접근합니다. 

### 동작 확인
더 이상 정밀한 클릭을 요구하지 않습니다. 이벤트가 정상 작동합니다. 

https://user-images.githubusercontent.com/31645195/219682826-be692594-3566-4513-856b-70cea3500ade.mov

