### PR TITLE
[Refactor] Toast UI 에 전역 상태값 추가 

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -20,6 +20,7 @@
 <body>
   <div id="root"></div>
   <div id="modal-root"></div>
+  <div id="toast-root"></div>
 </body>
 
 </html>

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Spinner } from './components/spinner';
-import { ToastMsg } from './components/toastMsg';
+import ToastPortal from './components/toastMsg/ToastPortal';
 import MainLayout from './pages/MainLayout';
 import NotFoundPage from './pages/NotFoundPage';
 
@@ -15,7 +15,7 @@ const DocumentPage = lazy(() => import('./pages/DocumentPage'));
 const Router = () => {
   return (
     <BrowserRouter>
-      <ToastMsg />
+      <ToastPortal />
       <Suspense fallback={<Spinner />}>
         <Routes>
           <Route path="/" element={<LandingPage />} />

--- a/frontend/src/atoms/toastMsgAtom.ts
+++ b/frontend/src/atoms/toastMsgAtom.ts
@@ -4,7 +4,8 @@ const toastMsgState = atom({
   key: 'toastMsg',
   default: {
     type: 'INIT', 
-    msg: ''
+    msg: '',
+    key: 0,
   }
 });
 

--- a/frontend/src/components/toastMsg/ToastMsg.tsx
+++ b/frontend/src/components/toastMsg/ToastMsg.tsx
@@ -8,17 +8,17 @@ import { devices } from '../../constants/breakpoints';
 
 const ToastMsg = () => {
   const theme = useTheme();
-  const toastMsg = useRecoilValue(toastMsgState);
+  const {type, msg, key} = useRecoilValue(toastMsgState);
   
   const ICON_SIZE = 24;
-  const TOAST_COLOR = toastMsg.type === 'INFO' 
+  const TOAST_COLOR = type === 'INFO' 
                         ? theme.primary 
                         : theme.caution;
 
-  if (toastMsg.type !== 'INIT') {
+  if (type !== 'INIT') {
     return (
-      <ToastMsgWrapper key={+new Date()} color={TOAST_COLOR}>
-        {toastMsg.type === 'INFO' 
+      <ToastMsgWrapper key={key} color={TOAST_COLOR}>
+        {type === 'INFO' 
           ? <CheckIcon 
               width={ICON_SIZE}
               height={ICON_SIZE} 
@@ -28,7 +28,7 @@ const ToastMsg = () => {
               height={ICON_SIZE} 
               fill={TOAST_COLOR} />
         }
-        <ToastText color={TOAST_COLOR}>{toastMsg.msg}</ToastText>
+        <ToastText color={TOAST_COLOR}>{msg}</ToastText>
       </ToastMsgWrapper>
     );
   } else {

--- a/frontend/src/components/toastMsg/ToastPortal.tsx
+++ b/frontend/src/components/toastMsg/ToastPortal.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { ToastMsg } from './ToastMsg';
+
+const ToastPortal = () => {
+  const toastRoot = document.getElementById('toast-root');
+  return ReactDOM.createPortal(<ToastMsg />, toastRoot as HTMLElement );
+};
+
+export default ToastPortal;

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -7,7 +7,8 @@ const useToast = () => {
   const alertToast = (type: string, msg: string) => {
     setToastMsg({
       type,
-      msg
+      msg,
+      key: +new Date(),
     });
   };
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 리팩토링

### 관련 이슈
- #119 

### 변경 사항
- Toast 를 Portal 을 이용하여 다른 root 에서 렌더링되도록 합니다. 
- Toast 의 전역 상태에 key 값을 추가합니다. 
  - key 값이 변경되면 애니메이션이 재실행된다는 점을 이용하여 구현했었습니다. 
  - key 값을 매번 컴포넌트 안에서 직접 생성하기 때문에 테마를 변경했을 경우 값이 바뀌어 리렌더링됩니다. 
  - 따라서 전역 상태에 key 값을 저장하여 테마가 바뀌었을 때 리렌더링되지 않게 합니다. 
- key 값은 alertToast 함수 내에서 상태를 업데이트할 때만 재생성합니다.  

### 동작 확인

이전과 다르게 테마를 바꾸어도 Toast UI 가 등장하지 않습니다. 

https://user-images.githubusercontent.com/31645195/219708799-c216bae8-be1d-4620-9035-10d0c97b800c.mov

