### PR TITLE
Fix: cors 허용 주소에 https 추가

### DIFF
--- a/backend/api/src/main.ts
+++ b/backend/api/src/main.ts
@@ -24,7 +24,16 @@ async function bootstrap() {
   app.use(cookieParser());
   app.use(json({ limit: '50mb' }));
   app.use(urlencoded({ limit: '50mb', extended: true }));
-  app.enableCors({ origin: ['http://localhost:3000', 'http://codocs.site', 'http://www.codocs.site'], credentials: true });
+  app.enableCors({
+    origin: [
+      'http://localhost:3000',
+      'http://codocs.site',
+      'https://codocs.site',
+      'http://www.codocs.site',
+      'https://www.codocs.site'
+    ],
+    credentials: true
+  });
 
   await app.listen(8000);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 수정

### 관련 이슈
- #133 

### 변경 사항
- AWS EC2에 HTTPS를 적용하고 나서 기존 코드에서 요청을 보내는 주소를 수정해야 했습니다. 

- CORS 허용 주소에 HTTPS 프로토콜을 포함시켰습니다. 

- 이외에도 ENV 파일에서 사용하는 주소도 변경했습니다. 

### 참고 자료 

[[AWS] EC2 인스턴스에 HTTPS 적용하기](https://kingofbackend.tistory.com/197)

[AWS 인증서 발급 받아 https 적용하기  - aws certificate https](https://bsssss.tistory.com/1084)

[[AWS] AWS 인증서로(ACM) HTTPS 적용해보기](https://develop-writing.tistory.com/127)

[[CentOS] Nginx 설치 및 사용 방법](https://hgko1207.github.io/2020/11/16/linux-9/)

[[AWS|GCP EC2] React+Next.js HTTPS 도메인 적용 방법 (Nginx 리버스프록시 연결 + snapd SSL 인증서 자동 갱신)](https://curryyou.tistory.com/510)